### PR TITLE
doc: Adding references to EdgeVPN network token format in getting started...

### DIFF
--- a/content/en/docs/Getting started/_index.md
+++ b/content/en/docs/Getting started/_index.md
@@ -244,7 +244,7 @@ chmod +x /usr/local/bin/kairos
 
 ```
 
-The CLI allows to register a node with a screenshot, an image, or a token. During pairing, the configuration is sent over, and the node will continue the installation process.
+The CLI allows to register a node with a QR Code screenshot, an QR Code image, or an EdgeVPN token. During pairing, the configuration is sent over, and the node will continue the installation process.
 
 In a terminal window from your desktop/workstation, run:
 
@@ -254,7 +254,7 @@ kairos register --reboot --device /dev/sda --config config.yaml
 
 **Note**:
 
-- By default, the CLI will automatically take a screenshot to get the QR code. Make sure it fits into the screen. Alternatively, an image path or a token can be supplied via arguments (e.g. `kairos register /img/path` or `kairos register <token>`).
+- By default, the CLI will automatically take a screenshot to get the QR code. Make sure it fits into the screen. Alternatively, an image path or an EdgeVPN token can be supplied via arguments (e.g. `kairos register /img/path` or `kairos register <EdgeVPN token>`).
 - The `--reboot` flag will make the node reboot automatically after the installation is completed.
 - The `--device` flag determines the specific drive where Kairos will be installed. Replace `/dev/sda` with your drive. Any existing data will be overwritten, so please be cautious.
 - The `--config` flag is used to specify the config file used by the installation process.

--- a/content/en/docs/Installation/automated.md
+++ b/content/en/docs/Installation/automated.md
@@ -48,6 +48,9 @@ kairos:
 # extra configuration
 ```
 
+The token `p2p.network_token` is a base64 encoded string which
+contains an [`edgevpn` token](https://github.com/mudler/edgevpn/blob/master/docs/content/en/docs/Concepts/Token/_index.md). For more information, [check out the architecture section](/docs/architecture/network).
+
 Save this file as `cloud_init.yaml`, then create an ISO with the following steps:
 
 1. Create a new directory and navigate to it:
@@ -55,12 +58,12 @@ Save this file as `cloud_init.yaml`, then create an ISO with the following steps
 $ mkdir -p build
 $ cd build
 ```
-2. Create empty `meta-data` and copy your config as `user-data`:
+1. Create empty `meta-data` and copy your config as `user-data`:
 ```bash
 $ touch meta-data
 $ cp -rfv cloud_init.yaml user-data
 ```
-3. Use `mkisofs` to create the ISO file:
+1. Use `mkisofs` to create the ISO file:
 ```bash
 $ mkisofs -output ci.iso -volid cidata -joliet -rock user-data meta-data
 ```

--- a/content/en/docs/Installation/manual.md
+++ b/content/en/docs/Installation/manual.md
@@ -34,6 +34,9 @@ p2p:
 # extra configuration
 ```
 
+The token `p2p.network_token` is a base64 encoded string which
+contains an [`edgevpn` token](https://github.com/mudler/edgevpn/blob/master/docs/content/en/docs/Concepts/Token/_index.md). For more information, [check out the architecture section](/docs/architecture/network).
+
 **Note**: 
 - The command is disruptive and will erase any content on the drive.
 - The parameter **"auto"** selects the biggest drive available in the machine.

--- a/content/en/docs/Installation/p2p.md
+++ b/content/en/docs/Installation/p2p.md
@@ -48,6 +48,9 @@ p2p:
 
 ```
 
+The token `p2p.network_token` is a base64 encoded string which
+contains an [`edgevpn` token](https://github.com/mudler/edgevpn/blob/master/docs/content/en/docs/Concepts/Token/_index.md).
+
 To enable the automatic cluster deployment with peer-to-peer technology, specify a `p2p.network_token`. To enable HA, set `p2p.auto.ha.master_nodes` to the number of wanted HA/master nodes. Additionally, the p2p block can be used to configure the VPN and other settings as needed.
 
 With these settings used to deploy all the nodes, those will automatically communicate and coordinate with each other to deploy and manage the Kubernetes cluster without the need for a control management interface and user intervention.

--- a/content/en/docs/Installation/qrcode.md
+++ b/content/en/docs/Installation/qrcode.md
@@ -16,6 +16,35 @@ By default Kairos will display a QR code after booting the ISO to install the ma
 ![livecd](https://user-images.githubusercontent.com/2420543/189219806-29b4deed-b4a1-4704-b558-7a60ae31caf2.gif)
 
 
+The QR Code is a base64 encoded string which is an [`edgevpn`](https://github.com/mudler/edgevpn) token.
+For example, you can scan the following QR Code from the video [Introduction to Kairos - timestamp 4:16](https://youtu.be/WzKf6WrL3nE?t=256).
+
+The base64 encoded string from the QR Code looks like this:
+
+```
+b3RwOgogIGRodDoKICAgIGludGVydmFsOiA5MjIzMzcyMDM2ODU0Nzc1ODA3CiAgICBrZXk6IFY0NTYzWUhKNzdNVFZaMkVNRFk1QVZINklDNk1UNkU0MjdMVE1OQ1MyTVhWM1FWR1VESVEKICAgIGxlbmd0aDogMzIKICBjcnlwdG86CiAgICBpbnRlcnZhbDogOTIyMzM3MjAzNjg1NDc3NTgwNwogICAga2V5OiBNUlZTU05KQ09WWjYyV0dETFlXRE9OUkNDUTU0TEFVMkxMRkVONURNNERHTFlGWEZYVTRBCiAgICBsZW5ndGg6IDMyCnJvb206IDI3V0pWN1lNSzdXUzdRWVUzV0xPSVNRQUxZT0dFUjRRNUpNVVRVUk1UREZKS0E1NVZZWUEKcmVuZGV6dm91czogcWZNcHRBdFRzaUhxVmZWSEJhaXRBbXZQZFdySkJEcEMKbWRuczogSFB0WmlsSUp4UFhiUVRUSE93ZHhiWGZ4S3JvVmJmZEgKbWF4X21lc3NhZ2Vfc2l6ZTogMjA5NzE1MjAK
+```
+
+Once this base64 string is decoded, the [`edgevpn` token](https://github.com/mudler/edgevpn/blob/master/docs/content/en/docs/Concepts/Token/_index.md) looks like this:
+
+```yaml
+otp:
+  dht:
+    interval: 9223372036854775807
+    key: V4563YHJ77MTVZ2EMDY5AVH6IC6MT6E427LTMNCS2MXV3QVGUDIQ
+    length: 32
+  crypto:
+    interval: 9223372036854775807
+    key: MRVSSNJCOVZ62WGDLYWDONRCCQ54LAU2LLFEN5DM4DGLYFXFXU4A
+    length: 32
+room: 27WJV7YMK7WS7QYU3WLOISQALYOGER4Q5JMUTURMTDFJKA55VYYA
+rendezvous: qfMptAtTsiHqVfVHBaitAmvPdWrJBDpC
+mdns: HPtZilIJxPXbQTTHOwdxbXfxKroVbfdH
+max_message_size: 20971520
+```
+
+For more information about EdgeVPN, [check out the architecture section](/docs/architecture/network).
+
 To trigger the installation process via QR code, you need to use the Kairos CLI and provide a Cloud Config, as described in the [Getting started guide](/docs/getting-started). You can also see some Cloud Config examples in our [Examples section](/docs/examples). The CLI is currently available only for Linux and Windows. It can be downloaded from the release artifact:
 
 ```bash

--- a/content/en/docs/Reference/cli.md
+++ b/content/en/docs/Reference/cli.md
@@ -39,7 +39,7 @@ COMMANDS:
 
 ## `create-config`
 
-Generates a new Kairos configuration file which can be used as `cloud-init`, with a new unique network token:
+Generates a new Kairos configuration file which can be used as `cloud-init`, with a new unique EdgeVPN network token:
 
 ```
 $ ./kairos create-config
@@ -71,7 +71,7 @@ stages:
 
 ## `generate-token`
 
-Generates a new network token which can be used in a configuration file:
+Generates a new EdgeVPN network token which can be used in a configuration file:
 
 ```
 $ ./kairos generate-token


### PR DESCRIPTION
... and Installation section

At my first view of the Kairos **getting started** section, I was confused by what the QR Code was. And I was confused by the term `TOKEN` or `NETWORK_TOKEN` which was use but not necessary explained in the getting started or Installation section. Therefore I propose to add a few explanation on the EdgeVPN token in those sections which are the first sections that a reader reads.