### PR TITLE
Add ubuntu arm rpi to image matrix

### DIFF
--- a/content/en/docs/Reference/image_matrix.md
+++ b/content/en/docs/Reference/image_matrix.md
@@ -20,6 +20,7 @@ Below is a list of the available images and their locations on the quay.io regis
 
 - The **Core** images do not include any Kubernetes engine and can be used as a base for customizations.
 - The **Standard** images include `k3s` and the [kairos provider](https://github.com/kairos-io/provider-kairos), which enables Kubernetes deployments and optionally enables [p2p](/docs/installation/p2p).
+- The **-img** repositories contain an img file which can be directly written to an SD card or USB drive for use with ARM devices.
 
 Base images are tagged with specific upstream versions (e.g. Ubuntu 20 LTS is pinned to Ubuntu 20:04, openSUSE to openSUSE leap 15.4, etc.).
 

--- a/content/en/docs/Reference/image_matrix.md
+++ b/content/en/docs/Reference/image_matrix.md
@@ -31,9 +31,9 @@ Base images are tagged with specific upstream versions (e.g. Ubuntu 20 LTS is pi
 | **Fedora based**                         | [core][c-fedora], [standard][k-fedora]                             |                                                                                                                                                            |
 | **openSUSE Leap based**                  | [core][c-opensuse-leap], [standard][k-opensuse-leap]               | [core][c-opensuse-leap-arm-rpi], [core-img][c-opensuse-leap-arm-rpi-img], [standard][k-opensuse-leap-arm-rpi], [standard-img][k-opensuse-leap-arm-rpi-img] |
 | **openSUSE Tumbleweed based**            | [core][c-opensuse-tumbleweed], [standard][k-opensuse-tumbleweed]   | [core][c-opensuse-tumbleweed-arm-rpi], [standard][k-opensuse-tumbleweed-arm-rpi]                                                                           |
-| **Ubuntu based (rolling)** **            | [core][c-ubuntu], [standard][k-ubuntu]                             |                                                                                                                                                            |
-| **Ubuntu based (22 LTS)** **             | [core][c-ubuntu-22-lts], [standard][k-ubuntu-22-lts]               |                                                                                                                                                            |
-| **Ubuntu based (20 LTS)** **             | [core][c-ubuntu-20-lts], [standard][k-ubuntu-20-lts]               |                                                                                                                                                            |
+| **Ubuntu based (rolling)** **            | [core][c-ubuntu], [standard][k-ubuntu]                             | [core][c-ubuntu-arm-rpi], [core-img][c-ubuntu-arm-rpi-img]                                                                                                     |
+| **Ubuntu based (22 LTS)** **             | [core][c-ubuntu-22-lts], [standard][k-ubuntu-22-lts]               | [core][c-ubuntu-22-lts-arm-rpi], [core-img][c-ubuntu-22-lts-arm-rpi-img]                                                                                                                                                          |
+| **Ubuntu based (20 LTS)** **             | [core][c-ubuntu-20-lts], [standard][k-ubuntu-20-lts]               | [core][c-ubuntu-20-lts-arm-rpi], [core-img][c-ubuntu-20-lts-arm-rpi-img]                                                                                                                                                           |
 | **Rocky Linux based**                    | [core][c-rockylinux], [standard][k-rockylinux]                     |                                                                                                                                                            |
 
 
@@ -50,8 +50,14 @@ Base images are tagged with specific upstream versions (e.g. Ubuntu 20 LTS is pi
 [c-opensuse-tumbleweed-arm-rpi]: https://quay.io/repository/kairos/core-opensuse-tumbleweed-arm-rpi
 [c-opensuse-tumbleweed-arm-rpi-img]: https://quay.io/repository/kairos/core-opensuse-tumbleweed-arm-rpi-img
 [c-ubuntu]: https://quay.io/repository/kairos/core-ubuntu
+[c-ubuntu-arm-rpi]: https://quay.io/repository/kairos/core-ubuntu-arm-rpi
+[c-ubuntu-arm-rpi-img]: https://quay.io/repository/kairos/core-ubuntu-arm-rpi-img
 [c-ubuntu-22-lts]: https://quay.io/repository/kairos/core-ubuntu-22-lts
+[c-ubuntu-22-lts-arm-rpi]: ]https://quay.io/repository/kairos/core-ubuntu-22-lts-arm-rpi
+[c-ubuntu-22-lts-arm-rpi-img]: https://quay.io/repository/kairos/core-ubuntu-22-lts-arm-rpi-img
 [c-ubuntu-20-lts]: https://quay.io/repository/kairos/core-ubuntu-20-lts
+[c-ubuntu-20-lts-arm-rpi]: https://quay.io/repository/kairos/core-ubuntu-20-lts-arm-rpi
+[c-ubuntu-20-lts-arm-rpi-img]: https://quay.io/repository/kairos/core-ubuntu-20-lts-arm-rpi-img
 [c-rockylinux]: https://quay.io/repository/kairos/core-rockylinux
 
 [k-alpine-opensuse-leap]: https://quay.io/repository/kairos/kairos-alpine-opensuse-leap


### PR DESCRIPTION
Document the existing images for Ubuntu RPi in the image matrix