### PR TITLE
Use LVM on RPi config example

### DIFF
--- a/content/en/docs/Installation/raspberry.md
+++ b/content/en/docs/Installation/raspberry.md
@@ -64,6 +64,7 @@ docker run -v $PWD:/HERE \
  -v /var/run/docker.sock:/var/run/docker.sock \
  --privileged -i --rm \
  --entrypoint=/build-arm-image.sh {{< registryURL >}}/osbuilder-tools:{{< osbuilderVersion >}} \
+ --use-lvm \
  --model rpi64 \
  --state-partition-size 6200 \
  --recovery-partition-size 4200 \


### PR DESCRIPTION
relates to https://github.com/kairos-io/kairos/issues/1435
