### PR TITLE
:bug: Kairosctl

### DIFF
--- a/content/en/docs/Getting started/_index.md
+++ b/content/en/docs/Getting started/_index.md
@@ -234,13 +234,13 @@ You can find instructions showing how to use the Kairos CLI below. In case you p
 To trigger the installation process via QR code, you need to use the Kairos CLI. The CLI is currently available only for Linux and Windows. It can be downloaded from the release artifact:
 
 ```bash
-curl -L https://github.com/kairos-io/provider-kairos/releases/download/v1.0.0/kairos-cli-v1.0.0-Linux-x86_64.tar.gz -o - | tar -xvzf - -C .
+curl -L https://github.com/kairos-io/provider-kairos/releases/download/{{<providerVersion>}}/kairosctl-.{{<providerVersion>}}-.linux-.amd64.tar.gz -o - | tar -xvzf - -C .
 ```
 
 ```bash
 # optionally, install the CLI locally
-mv kairos-cli /usr/local/bin/kairos
-chmod +x /usr/local/bin/kairos
+mv kairosctl /usr/local/bin/kairosctl
+chmod +x /usr/local/bin/kairosctl
 
 ```
 
@@ -249,12 +249,12 @@ The CLI allows to register a node with a QR Code screenshot, an QR Code image, o
 In a terminal window from your desktop/workstation, run:
 
 ```
-kairos register --reboot --device /dev/sda --config config.yaml
+kairosctl register --reboot --device /dev/sda --config config.yaml
 ```
 
 **Note**:
 
-- By default, the CLI will automatically take a screenshot to get the QR code. Make sure it fits into the screen. Alternatively, an image path or an EdgeVPN token can be supplied via arguments (e.g. `kairos register /img/path` or `kairos register <EdgeVPN token>`).
+- By default, the CLI will automatically take a screenshot to get the QR code. Make sure it fits into the screen. Alternatively, an image path or an EdgeVPN token can be supplied via arguments (e.g. `kairosctl register /img/path` or `kairosctl register <EdgeVPN token>`).
 - The `--reboot` flag will make the node reboot automatically after the installation is completed.
 - The `--device` flag determines the specific drive where Kairos will be installed. Replace `/dev/sda` with your drive. Any existing data will be overwritten, so please be cautious.
 - The `--config` flag is used to specify the config file used by the installation process.

--- a/content/en/docs/Installation/p2p.md
+++ b/content/en/docs/Installation/p2p.md
@@ -255,10 +255,10 @@ To add new nodes to the network, follow the same process as before and use the s
 
 ## Connect to the nodes
 
-To connect to the nodes, you can use the kairos-cli and provide the network_token to establish a tunnel to the nodes network.
+To connect to the nodes, you can use `kairosctl` and provide the network_token to establish a tunnel to the nodes network.
 
 ```bash
-sudo kairos bridge --network-token <TOKEN>
+sudo kairosctl bridge --network-token <TOKEN>
 ```
 
 This command creates a TUN device on your machine and allows you to communicate with each node in the cluster.
@@ -274,7 +274,7 @@ An API will be also available at [localhost:8080](http://localhost:8080) for ins
 To get the cluster `kubeconfig`, you can log in to the master node and retrieve it from the engine (e.g., it is located at `/etc/rancher/k3s/k3s.yaml` for K3s) or use the Kairos CLI. If using the CLI, you must be connected to the bridge or logged in from one of the nodes and run the following command in the console:
 
 ```bash
-kairos get-kubeconfig > kubeconfig
+kairosctl get-kubeconfig > kubeconfig
 ```
 
 {{% alert title="Note" color="info" %}}

--- a/content/en/docs/Installation/qrcode.md
+++ b/content/en/docs/Installation/qrcode.md
@@ -57,7 +57,7 @@ The CLI allows to register a node with a screenshot, an image, or a token. Durin
 In a terminal window from your desktop/workstation, run:
 
 ```
-kairos register --reboot --device /dev/sda --config config.yaml
+kairosctl register --reboot --device /dev/sda --config config.yaml
 ```
 
 - The `--reboot` flag will make the node reboot automatically after the installation is completed.
@@ -65,7 +65,7 @@ kairos register --reboot --device /dev/sda --config config.yaml
 - The `--config` flag is used to specify the config file used by the installation process.
 
 {{% alert title="Note" %}}
-By default, the CLI will automatically take a screenshot to get the QR code. Make sure it fits into the screen. Alternatively, an image path or a token can be supplied via arguments (e.g. `kairos register /img/path` or `kairos register <token>`).
+By default, the CLI will automatically take a screenshot to get the QR code. Make sure it fits into the screen. Alternatively, an image path or a token can be supplied via arguments (e.g. `kairosctl register /img/path` or `kairosctl register <token>`).
 {{% /alert %}}
 
 After a few minutes, the configuration is distributed to the node and the installation starts. At the end of the installation, the system is automatically rebooted.

--- a/content/en/docs/Reference/configuration.md
+++ b/content/en/docs/Reference/configuration.md
@@ -541,7 +541,7 @@ Define a custom ID for the Kubernetes cluster. This can be used to create multip
 
 ### `p2p.dns`
 
-When the `p2p.dns` is set to `true` the embedded DNS is configured on the node. This allows to propagate custom records to the nodes by using the blockchain DNS server. For example, this is assuming `kairos bridge` is running in a separate terminal:
+When the `p2p.dns` is set to `true` the embedded DNS is configured on the node. This allows to propagate custom records to the nodes by using the blockchain DNS server. For example, this is assuming `kairosctl bridge` is running in a separate terminal:
 
 ```bash
 curl -X POST http://localhost:8080/api/dns --header "Content-Type: application/json" -d '{ "Regex": "foo.bar", "Records": { "A": "2.2.2.2" } }'

--- a/content/en/docs/Reference/kairosctl.md
+++ b/content/en/docs/Reference/kairosctl.md
@@ -1,43 +1,47 @@
 ---
-title: "CLI"
-linkTitle: "CLI"
+title: "kairosctl"
+linkTitle: "kairosctl"
 weight: 3
 date: 2022-11-13
 description: >
 ---
 
-A CLI is provided as part of releases associated to each Kairos version.
-
-The CLI can be used from an external machine to generate network tokens and pair nodes on first-boot.
+The `kairosctl` binary is provided as part of releases associated to each Kairos version. It can be used from an external machine to generate network tokens and pair nodes on first-boot.
 
 ```
-./kairos --help
+./kairosctl --help
 NAME:
-   kairos - kairos (register|install)
+   kairosctl - A new cli application
 
 USAGE:
-    [global options] command [command options] [arguments...]
+   kairosctl [global options] command [command options] [arguments...]
 
 VERSION:
-   0.1
-
-DESCRIPTION:
-   kairos registers and installs kairos boxes
+   0.0.0
 
 AUTHOR:
    Ettore Di Giacinto
 
 COMMANDS:
-   register
-   create-config, c
-   generate-token, g
-   setup, s
-   get-kubeconfig
-   install, i
-   help, h            Shows a list of commands or help for one command
+   register        Registers and bootstraps a node
+   bridge          Connect to a kairos VPN network
+   get-kubeconfig  Return a deployment kubeconfig
+   role            Set or list node roles
+   help, h         Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --help, -h     show help
+   --version, -v  print the version
+
+COPYRIGHT:
+   Ettore Di Giacinto
 ```
 
 ## `create-config`
+
+{{% alert title="Warning" %}}
+This command has not yet been migrated to kairosctl. Use the kairos-agent in the meantime.
+{{% /alert %}}
 
 Generates a new Kairos configuration file which can be used as `cloud-init`, with a new unique EdgeVPN network token:
 
@@ -70,6 +74,10 @@ stages:
 ```
 
 ## `generate-token`
+
+{{% alert title="Warning" %}}
+This command has not yet been migrated to kairosctl. Use the kairos-agent in the meantime.
+{{% /alert %}}
 
 Generates a new EdgeVPN network token which can be used in a configuration file:
 
@@ -114,14 +122,14 @@ OPTIONS:
    --poweroff
 ```
 
-When booting Kairos via ISO, the boot process ends up in displaying a QR code which can be parsed by `kairos register` from another machine.
+When booting Kairos via ISO, the boot process ends up in displaying a QR code which can be parsed by `kairosctl register` from another machine.
 
 ### Taking a screenshot
 
 `register` by default takes a screenshot and tries to find a QR code in it:
 
 ```
-kairos register
+kairosctl register
 ```
 
 ### Providing a QR code image/screenshot manually
@@ -129,7 +137,7 @@ kairos register
 It can be also be specified an image:
 
 ```
-kairos register <file.png>
+kairosctl register <file.png>
 ```
 
 After the pairing is done, the node will start installation with the provided options.
@@ -141,11 +149,3 @@ A `--device` and a `--config` file are required in order to have a functional in
 Connect to the nodes in the VPN P2P network by creating a tun device on the host.
 
 It needs a `--network-token`(`$NETWORK_TOKEN`) argument and exposes an API endpoint available at [localhost:8080](http://localhost:8080) to monitor the network status.
-
-## `install`
-
-Is called by Kairos nodes on boot and not meant to be used manually. It kicks in the installation and the QR pairing process.
-
-## `setup`
-
-Is called by Kairos nodes on boot and not meant to be used manually. It prepares `edgevpn` and K3s bootstrapping the node and the VPN.

--- a/content/en/docs/Reference/recovery_mode.md
+++ b/content/en/docs/Reference/recovery_mode.md
@@ -36,7 +36,7 @@ At this stage, take a screenshot or a photo and save the image with the QR code.
 In the another machine that you are using to connect to your server, (your workstation, a jumpbox, or other) use the Kairos CLI to connect over the remote machine:
 
 ```
-$ ./kairos bridge --qr-code-image /path/to/image.png
+$ ./kairosctl bridge --qr-code-image /path/to/image.png
  INFO   Connecting to service kAIsuqiwKR
  INFO   SSH access password is yTXlkak
  INFO   SSH server reachable at 127.0.0.1:2200


### PR DESCRIPTION
- Generate download link for `kairosctl` dynamically using provider version
- Update docs to use kairosctl instead of kairos-cli