### PR TITLE
Move links to be relative to the current dir

### DIFF
--- a/content/en/docs/Advanced/build.md
+++ b/content/en/docs/Advanced/build.md
@@ -21,7 +21,7 @@ Note the same can be achieved by using advanced configuration and actually modif
 
 To achieve that, Kairos provides a set of Kubernetes Native Extensions that allow to programmatically generate Installable mediums, Cloud Images and Netboot artifacts. These provide on-demand customization and exploit Kubernetes patterns to automatically provision nodes using control-plane management clusters - however, the same toolset can be used to build appliances for local development and debugging.
 
-The [automated](/docs/installation/automated) section already shows some examples of how to leverage the Kubernetes Native Extensions and use the Kairos images to build appliances, in this section we will cover and describe in detail how to leverage the CRDs and the Kairos factory to build custom appliances.
+The [automated]({{< ref "../installation/automated" >}}) section already shows some examples of how to leverage the Kubernetes Native Extensions and use the Kairos images to build appliances, in this section we will cover and describe in detail how to leverage the CRDs and the Kairos factory to build custom appliances.
 
 ## Prerequisites
 
@@ -107,7 +107,7 @@ spec:
 
 Apply the manifest with `kubectl apply`.
 
-Note, the CRD allows to specify a custom Cloud config file, [check out the full configuration reference](/docs/reference/configuration).
+Note, the CRD allows to specify a custom Cloud config file, [check out the full configuration reference]({{< ref "../reference/configuration" >}}).
 
 As mentioned above, there is an nginx server that will serve the built artifacts as soon as they are ready.
 By default, it is exposed with a `NodePort` type of service. Use the following commands

--- a/content/en/docs/Advanced/build.md
+++ b/content/en/docs/Advanced/build.md
@@ -21,7 +21,7 @@ Note the same can be achieved by using advanced configuration and actually modif
 
 To achieve that, Kairos provides a set of Kubernetes Native Extensions that allow to programmatically generate Installable mediums, Cloud Images and Netboot artifacts. These provide on-demand customization and exploit Kubernetes patterns to automatically provision nodes using control-plane management clusters - however, the same toolset can be used to build appliances for local development and debugging.
 
-The [automated]({{< ref "../installation/automated" >}}) section already shows some examples of how to leverage the Kubernetes Native Extensions and use the Kairos images to build appliances, in this section we will cover and describe in detail how to leverage the CRDs and the Kairos factory to build custom appliances.
+The [automated]({{< relref "../installation/automated" >}}) section already shows some examples of how to leverage the Kubernetes Native Extensions and use the Kairos images to build appliances, in this section we will cover and describe in detail how to leverage the CRDs and the Kairos factory to build custom appliances.
 
 ## Prerequisites
 
@@ -107,7 +107,7 @@ spec:
 
 Apply the manifest with `kubectl apply`.
 
-Note, the CRD allows to specify a custom Cloud config file, [check out the full configuration reference]({{< ref "../reference/configuration" >}}).
+Note, the CRD allows to specify a custom Cloud config file, [check out the full configuration reference]({{< relref "../reference/configuration" >}}).
 
 As mentioned above, there is an nginx server that will serve the built artifacts as soon as they are ready.
 By default, it is exposed with a `NodePort` type of service. Use the following commands

--- a/content/en/docs/Advanced/bundles.md
+++ b/content/en/docs/Advanced/bundles.md
@@ -69,7 +69,7 @@ metallb:
 
 ## Bundle types
 
-Bundles can carry also binaries that can be overlayed in the rootfs, either while [building images]({{< ref "build" >}}) or with [Live layering]({{< ref "livelayering" >}}).
+Bundles can carry also binaries that can be overlayed in the rootfs, either while [building images]({{< relref "build" >}}) or with [Live layering]({{< relref "livelayering" >}}).
 
 Kairos supports three types of bundles:
 

--- a/content/en/docs/Advanced/bundles.md
+++ b/content/en/docs/Advanced/bundles.md
@@ -69,7 +69,7 @@ metallb:
 
 ## Bundle types
 
-Bundles can carry also binaries that can be overlayed in the rootfs, either while [building images](/docs/advanced/build) or with [Live layering](https://kairos.io/docs/advanced/livelayering/).
+Bundles can carry also binaries that can be overlayed in the rootfs, either while [building images]({{< ref "build" >}}) or with [Live layering]({{< ref "livelayering" >}}).
 
 Kairos supports three types of bundles:
 

--- a/content/en/docs/Advanced/customizing.md
+++ b/content/en/docs/Advanced/customizing.md
@@ -5,10 +5,10 @@ weight: 2
 description: >
 ---
 
-Kairos is an open source, container-based operating system. To modify Kairos and add a package, you'll need to build a container image from the [Kairos images](/docs/reference/image_matrix/). Here's an example with Docker which adds `figlet`:
+Kairos is an open source, container-based operating system. To modify Kairos and add a package, you'll need to build a container image from the [Kairos images]({{< ref "../reference/image_matrix" >}}). Here's an example with Docker which adds `figlet`:
 
 ```docker
-# Use images from docs/reference/image_matrix/
+# Use images from reference/image_matrix/
 FROM quay.io/kairos/kairos:opensuse-latest
 
 RUN zypper in -y figlet
@@ -45,7 +45,7 @@ c58930881bc4: Pushed
 ...
 ```
 
-You can use your custom image when [upgrading nodes manually](/docs/upgrade/manual), [with Kubernetes](/docs/upgrade/kubernetes) or [specifying it in the cloud-config during installation](/docs/examples/core). Here's how to do it manually with the `kairos-agent` command:
+You can use your custom image when [upgrading nodes manually]({{< ref "../upgrade/manual" >}}), [with Kubernetes]({{< ref "../upgrade/kubernetes" >}}) or [specifying it in the cloud-config during installation]({{< ref "../examples/core" >}}). Here's how to do it manually with the `kairos-agent` command:
 
 ```
 node:/home/kairos # kairos-agent upgrade --image docker.io/<your-org>/myos:0.1
@@ -114,7 +114,7 @@ If you are using an Alpine-based distribution, modifying the kernel is only poss
 
 {{% /alert %}}
 
-After you have modified the kernel and initrd, you can use the kairos-agent upgrade command to update your nodes, or [within Kubernetes](/docs/upgrade/kubernetes).
+After you have modified the kernel and initrd, you can use the kairos-agent upgrade command to update your nodes, or [within Kubernetes]({{< ref "../upgrade/kubernetes" >}}).
 
 
 ## Customizing the file system hierarchy using custom mounts.
@@ -156,4 +156,4 @@ install:
 ...
 ```
 Note, that these paths should exist in the container file-system used to create the ISO.
-See [ISO customization](/docs/Advanced/customizing/) above.
+See [ISO customization]({{< ref "../Advanced/customizing" >}}) above.

--- a/content/en/docs/Advanced/customizing.md
+++ b/content/en/docs/Advanced/customizing.md
@@ -5,7 +5,7 @@ weight: 2
 description: >
 ---
 
-Kairos is an open source, container-based operating system. To modify Kairos and add a package, you'll need to build a container image from the [Kairos images]({{< ref "../reference/image_matrix" >}}). Here's an example with Docker which adds `figlet`:
+Kairos is an open source, container-based operating system. To modify Kairos and add a package, you'll need to build a container image from the [Kairos images]({{< relref "../reference/image_matrix" >}}). Here's an example with Docker which adds `figlet`:
 
 ```docker
 # Use images from reference/image_matrix/
@@ -45,7 +45,7 @@ c58930881bc4: Pushed
 ...
 ```
 
-You can use your custom image when [upgrading nodes manually]({{< ref "../upgrade/manual" >}}), [with Kubernetes]({{< ref "../upgrade/kubernetes" >}}) or [specifying it in the cloud-config during installation]({{< ref "../examples/core" >}}). Here's how to do it manually with the `kairos-agent` command:
+You can use your custom image when [upgrading nodes manually]({{< relref "../upgrade/manual" >}}), [with Kubernetes]({{< relref "../upgrade/kubernetes" >}}) or [specifying it in the cloud-config during installation]({{< relref "../examples/core" >}}). Here's how to do it manually with the `kairos-agent` command:
 
 ```
 node:/home/kairos # kairos-agent upgrade --image docker.io/<your-org>/myos:0.1
@@ -114,7 +114,7 @@ If you are using an Alpine-based distribution, modifying the kernel is only poss
 
 {{% /alert %}}
 
-After you have modified the kernel and initrd, you can use the kairos-agent upgrade command to update your nodes, or [within Kubernetes]({{< ref "../upgrade/kubernetes" >}}).
+After you have modified the kernel and initrd, you can use the kairos-agent upgrade command to update your nodes, or [within Kubernetes]({{< relref "../upgrade/kubernetes" >}}).
 
 
 ## Customizing the file system hierarchy using custom mounts.
@@ -156,4 +156,4 @@ install:
 ...
 ```
 Note, that these paths should exist in the container file-system used to create the ISO.
-See [ISO customization]({{< ref "../Advanced/customizing" >}}) above.
+See [ISO customization]({{< relref "../Advanced/customizing" >}}) above.

--- a/content/en/docs/Advanced/partition_encryption.md
+++ b/content/en/docs/Advanced/partition_encryption.md
@@ -298,4 +298,4 @@ echo '{ "data": "{ \"label\": \"LABEL\" }"}' | sudo -E WSS_SERVER="http://localh
 
 ## Notes
 
-If encryption is enabled and `COS_PERSISTENT` is set to be encrypted, every cloud config file in `/usr/local/cloud-config` will be protected and can be used to store sensitive data. However, it's important to keep in mind that although the contents of /usr/local are retained between reboots and upgrades, they will not be preserved during a [resets]({{< ref "../reference/reset" >}}).
+If encryption is enabled and `COS_PERSISTENT` is set to be encrypted, every cloud config file in `/usr/local/cloud-config` will be protected and can be used to store sensitive data. However, it's important to keep in mind that although the contents of /usr/local are retained between reboots and upgrades, they will not be preserved during a [resets]({{< relref "../reference/reset" >}}).

--- a/content/en/docs/Advanced/partition_encryption.md
+++ b/content/en/docs/Advanced/partition_encryption.md
@@ -298,4 +298,4 @@ echo '{ "data": "{ \"label\": \"LABEL\" }"}' | sudo -E WSS_SERVER="http://localh
 
 ## Notes
 
-If encryption is enabled and `COS_PERSISTENT` is set to be encrypted, every cloud config file in `/usr/local/cloud-config` will be protected and can be used to store sensitive data. However, it's important to keep in mind that although the contents of /usr/local are retained between reboots and upgrades, they will not be preserved during a [resets](/docs/reference/reset).
+If encryption is enabled and `COS_PERSISTENT` is set to be encrypted, every cloud config file in `/usr/local/cloud-config` will be protected and can be used to store sensitive data. However, it's important to keep in mind that although the contents of /usr/local are retained between reboots and upgrades, they will not be preserved during a [resets]({{< ref "../reference/reset" >}}).

--- a/content/en/docs/Architecture/container.md
+++ b/content/en/docs/Architecture/container.md
@@ -40,7 +40,7 @@ If you are familiar with Dockerfiles, then you are good to go to roll your own c
 
 ## Container Image based OS
 
-The Image support matrix in [here]({{< ref "../reference/image_matrix" >}}) lists all the container images built from our CI on every release of Kairos.
+The Image support matrix in [here]({{< relref "../reference/image_matrix" >}}) lists all the container images built from our CI on every release of Kairos.
 
 To inspect an image and run it locally, you can use a container engine like Docker or Podman:
 
@@ -89,7 +89,7 @@ total 102M
 6692029 -rw-r--r-- 1 root root  11M Apr 16  2020 vmlinuz-5.14.21-150400.24.21-default
 ```
 
-The CI process generates bootable medium by the container images, and similarly, we can modify this image to introduce our changes and remaster an ISO as described in [Automated installation]({{< ref "../installation/automated" >}}), but that can be resumed in the following steps:
+The CI process generates bootable medium by the container images, and similarly, we can modify this image to introduce our changes and remaster an ISO as described in [Automated installation]({{< relref "../installation/automated" >}}), but that can be resumed in the following steps:
 
 ```bash
 $ docker run -ti --name custom-container {{< registryURL >}}/core-{{< flavor >}}:{{< kairosVersion >}}
@@ -113,8 +113,8 @@ custom-iso.iso custom-iso.iso.sha256
 
 In order to go further and upgrade nodes using this image, now the only requirement is to push it in a container registry and upgrade the nodes using that container image.
 
-For upgrading to a container image see [manual upgrades]({{< ref "../upgrade/manual" >}}) and [kubernetes upgrades]({{< ref "../upgrade/kubernetes" >}}).
+For upgrading to a container image see [manual upgrades]({{< relref "../upgrade/manual" >}}) and [kubernetes upgrades]({{< relref "../upgrade/kubernetes" >}}).
 
 ## See also
 
-- [ISO remastering]({{< ref "../installation/automated#iso-remastering" >}})
+- [ISO remastering]({{< relref "../installation/automated#iso-remastering" >}})

--- a/content/en/docs/Architecture/container.md
+++ b/content/en/docs/Architecture/container.md
@@ -40,7 +40,7 @@ If you are familiar with Dockerfiles, then you are good to go to roll your own c
 
 ## Container Image based OS
 
-The Image support matrix in [here](/docs/reference/image_matrix) lists all the container images built from our CI on every release of Kairos.
+The Image support matrix in [here]({{< ref "../reference/image_matrix" >}}) lists all the container images built from our CI on every release of Kairos.
 
 To inspect an image and run it locally, you can use a container engine like Docker or Podman:
 
@@ -89,7 +89,7 @@ total 102M
 6692029 -rw-r--r-- 1 root root  11M Apr 16  2020 vmlinuz-5.14.21-150400.24.21-default
 ```
 
-The CI process generates bootable medium by the container images, and similarly, we can modify this image to introduce our changes and remaster an ISO as described in [Automated installation](/docs/installation/automated), but that can be resumed in the following steps:
+The CI process generates bootable medium by the container images, and similarly, we can modify this image to introduce our changes and remaster an ISO as described in [Automated installation]({{< ref "../installation/automated" >}}), but that can be resumed in the following steps:
 
 ```bash
 $ docker run -ti --name custom-container {{< registryURL >}}/core-{{< flavor >}}:{{< kairosVersion >}}
@@ -113,8 +113,8 @@ custom-iso.iso custom-iso.iso.sha256
 
 In order to go further and upgrade nodes using this image, now the only requirement is to push it in a container registry and upgrade the nodes using that container image.
 
-For upgrading to a container image see [manual upgrades](/docs/upgrade/manual) and [kubernetes upgrades](/docs/upgrade/kubernetes).
+For upgrading to a container image see [manual upgrades]({{< ref "../upgrade/manual" >}}) and [kubernetes upgrades]({{< ref "../upgrade/kubernetes" >}}).
 
 ## See also
 
-- [ISO remastering](/docs/installation/automated#iso-remastering)
+- [ISO remastering]({{< ref "../installation/automated#iso-remastering" >}})

--- a/content/en/docs/Architecture/meta.md
+++ b/content/en/docs/Architecture/meta.md
@@ -12,7 +12,7 @@ We like to define Kairos as a meta-Linux Distribution, as its goal is to convert
 
 The Kairos stack is composed of the following:
 
-- A core OS image release for each flavor in ISO, qcow2, and other similar formats (see [the list of supported distributions](/docs/reference/image_matrix)) provided for user convenience
+- A core OS image release for each flavor in ISO, qcow2, and other similar formats (see [the list of supported distributions]({{< ref "../reference/image_matrix" >}})) provided for user convenience
 - A release with K3s embedded.
 - A set of Kubernetes Native API components (CRDs) to install into the control-plane node, to manage deployment, artifacts creation, and lifecycle (WIP).
 - A set of Kubernetes Native API components (CRDs) to install into the target nodes to manage and control the node after deployment (WIP).

--- a/content/en/docs/Architecture/meta.md
+++ b/content/en/docs/Architecture/meta.md
@@ -12,7 +12,7 @@ We like to define Kairos as a meta-Linux Distribution, as its goal is to convert
 
 The Kairos stack is composed of the following:
 
-- A core OS image release for each flavor in ISO, qcow2, and other similar formats (see [the list of supported distributions]({{< ref "../reference/image_matrix" >}})) provided for user convenience
+- A core OS image release for each flavor in ISO, qcow2, and other similar formats (see [the list of supported distributions]({{< relref "../reference/image_matrix" >}})) provided for user convenience
 - A release with K3s embedded.
 - A set of Kubernetes Native API components (CRDs) to install into the control-plane node, to manage deployment, artifacts creation, and lifecycle (WIP).
 - A set of Kubernetes Native API components (CRDs) to install into the target nodes to manage and control the node after deployment (WIP).

--- a/content/en/docs/Architecture/network.md
+++ b/content/en/docs/Architecture/network.md
@@ -16,7 +16,7 @@ To address these challenges, Kairos provides an easy and robust solution for dep
 In this document, we will examine the advantages of using Kairos to deploy Kubernetes clusters at the edge, and how p2p technology facilitates self-coordination for a zero-touch configuration experience. We will also explore how Kairos' highly adaptable and container-based approach, combined with an immutable OS and meta-distribution, makes it an excellent choice for edge deployments.
 
 {{% alert title="Note" %}}
-You can also watch our [Kairos and libp2p video]({{< ref "../media/#how-kairos-uses-libp2p" >}} "Media") in the [Media Section]({{< ref "../media" >}} "Media")
+You can also watch our [Kairos and libp2p video]({{< relref "../media/#how-kairos-uses-libp2p" >}} "Media") in the [Media Section]({{< relref "../media" >}} "Media")
 {{% /alert %}}
 
 ## Overview: P2P for self-coordination
@@ -27,14 +27,14 @@ Kairos creates self-coordinated, fully meshed clusters at the edge by using a co
 
 This design is made up of several components:
 
-- The Kairos base OS with support for different distribution flavors and k3s combinations (see our support matrix [here]({{< ref "../reference/image_matrix" >}})).
+- The Kairos base OS with support for different distribution flavors and k3s combinations (see our support matrix [here]({{< relref "../reference/image_matrix" >}})).
 - A Virtual private network interface ([EdgeVPN](https://github.com/mudler/edgevpn) which leverages [libp2p](https://github.com/libp2p/go-libp2p)).
 - K3s/CNI configured to work with the VPN interface.
 - A shared ledger accessible to all nodes in the p2p private network.
 
 By using libp2p as the transport layer, Kairos can abstract connections between the nodes and use it as a coordination mechanism. The shared ledger serves as a cache to store additional data, such as node tokens to join nodes to the cluster or the cluster topology, and is accessible to all nodes in the P2P private network. The VPN interface is automatically configured and self-coordinated, requiring zero-configuration and no user intervention.
 
-Moreover, any application at the OS level can use P2P functionalities by using Virtual IPs within the VPN. The user only needs to provide a generated shared token containing OTP seeds for rendezvous points used during connection bootstrapping between the peers. It's worth noting that the VPN is optional, and the shared ledger can be used to coordinate and set up other forms of networking between the cluster nodes, such as KubeVIP. (See this example [here]({{< ref "../examples/multi-node-p2p-ha-kubevip" >}}))
+Moreover, any application at the OS level can use P2P functionalities by using Virtual IPs within the VPN. The user only needs to provide a generated shared token containing OTP seeds for rendezvous points used during connection bootstrapping between the peers. It's worth noting that the VPN is optional, and the shared ledger can be used to coordinate and set up other forms of networking between the cluster nodes, such as KubeVIP. (See this example [here]({{< relref "../examples/multi-node-p2p-ha-kubevip" >}}))
 
 ## Implementation
 
@@ -88,7 +88,7 @@ Nonetheless, these tradeoffs can be overcome, and new features can be added due 
 - The p2p layer is decentralized and can span across different networks by using DHT and a bootstrap server
 - Self-coordination simplifies the provisioning experience
 - Internal cluster traffic can also be offloaded to other mechanisms if network performance is a prerequisite
-- For instance, with [KubeVIP]({{< ref "../examples/multi-node-p2p-ha-kubevip" >}}), new nodes can join the network and become cluster members even after the cluster provisioning phase, making EdgeVPN a scalable solution.
+- For instance, with [KubeVIP]({{< relref "../examples/multi-node-p2p-ha-kubevip" >}}), new nodes can join the network and become cluster members even after the cluster provisioning phase, making EdgeVPN a scalable solution.
 
 ### Why a VPN ?
 
@@ -106,7 +106,7 @@ Additionally, network configuration is simplified with a VPN. Without a VPN, `et
 
 In terms of networking, a Kubernetes cluster without a VPN handles cluster IPs and networking natively without additional layers. However, with a VPN, Kubernetes network services will have Cluster IPs below the VPN. This means that all internal Kubernetes communication goes through the VPN. While the additional end-to-end encrypted network layer might add some latency, it is observed typically to be only 0-1ms in LAN. However, due to the Encryption layers, the CPU usage might be high if used for high-demanding traffic.
 
-It's also worth noting that while a VPN provides a unified network environment, it may not be necessary or appropriate for all use cases. Users can choose to opt-out of using the VPN and leverage only the coordination aspect, for example, with KubeVIP. Ultimately, the decision to use a VPN should be based on the specific needs and requirements of your Kubernetes cluster, and as such you can just use the co-ordination aspect and leverage for instance [KubeVIP]({{< ref "../examples/multi-node-p2p-ha-kubevip" >}}).
+It's also worth noting that while a VPN provides a unified network environment, it may not be necessary or appropriate for all use cases. Users can choose to opt-out of using the VPN and leverage only the coordination aspect, for example, with KubeVIP. Ultimately, the decision to use a VPN should be based on the specific needs and requirements of your Kubernetes cluster, and as such you can just use the co-ordination aspect and leverage for instance [KubeVIP]({{< relref "../examples/multi-node-p2p-ha-kubevip" >}}).
 
 ### Packet flow
 
@@ -131,7 +131,7 @@ Assuming that we want to establish an SSH connection from Node A to Node B throu
 
 ### Controller
 
-A set of Kubernetes Native Extensions ([Entangle]({{< ref "../reference/entangle" >}})) provides peer-to-peer functionalities also to existing clusters by allowing to bridge connection with the same design architecture described above.
+A set of Kubernetes Native Extensions ([Entangle]({{< relref "../reference/entangle" >}})) provides peer-to-peer functionalities also to existing clusters by allowing to bridge connection with the same design architecture described above.
 
 It can be used to:
 
@@ -139,7 +139,7 @@ It can be used to:
 - Bridge external connections to cluster
 - Setup EdgeVPN as a daemonset between cluster nodes
 
-See also the Entangle [documentation]({{< ref "../reference/entangle" >}}) to learn more about it.
+See also the Entangle [documentation]({{< relref "../reference/entangle" >}}) to learn more about it.
 
 ## Benefits
 
@@ -150,7 +150,7 @@ See also the Entangle [documentation]({{< ref "../reference/entangle" >}}) to le
 The use of p2p technology to enable self-coordination of Kubernetes clusters in Kairos offers a number of benefits:
 
 1. **Simplified deployment**: Deploying Kubernetes clusters at the edge is greatly simplified. Users don’t need to specify any network settings or use a control management interface to set up and manage their clusters.
-1. **Easy customization**: Kairos offers a highly customizable approach to deploying Kubernetes clusters at the edge. Users can choose from a range of meta distributions, including openSUSE, Ubuntu, Alpine and [many others]({{< ref "../reference/image_matrix" >}}), and customize the configuration of their clusters as needed.
+1. **Easy customization**: Kairos offers a highly customizable approach to deploying Kubernetes clusters at the edge. Users can choose from a range of meta distributions, including openSUSE, Ubuntu, Alpine and [many others]({{< relref "../reference/image_matrix" >}}), and customize the configuration of their clusters as needed.
 1. **Automatic coordination**: With Kairos, the coordination of Kubernetes clusters is completely automated. The p2p network is used as a coordination mechanism for the nodes, allowing them to communicate and coordinate with each other without the need for any external management interface. This means that users can set up and manage their Kubernetes clusters at the edge with minimal effort, freeing up their time to focus on other tasks.
 1. **Secure and replicated**: The use of rendezvous points and a shared ledger, encrypted with AES and rotated via OTP, ensures that the p2p network is secure and resilient. This is especially important when deploying Kubernetes clusters at the edge, where network conditions can be unpredictable.
 1. **Resilient**: Kairos ensures that the cluster remains resilient, even in the face of network disruptions or failures. By using VirtualIPs, nodes can communicate with each other without the need for static IPs, and the cluster's etcd database remains unaffected by any disruptions.

--- a/content/en/docs/Architecture/network.md
+++ b/content/en/docs/Architecture/network.md
@@ -16,7 +16,7 @@ To address these challenges, Kairos provides an easy and robust solution for dep
 In this document, we will examine the advantages of using Kairos to deploy Kubernetes clusters at the edge, and how p2p technology facilitates self-coordination for a zero-touch configuration experience. We will also explore how Kairos' highly adaptable and container-based approach, combined with an immutable OS and meta-distribution, makes it an excellent choice for edge deployments.
 
 {{% alert title="Note" %}}
-You can also watch our [Kairos and libp2p video]({{< ref "docs/media/#how-kairos-uses-libp2p" >}} "Media") in the [Media Section]({{< ref "docs/media" >}} "Media")
+You can also watch our [Kairos and libp2p video]({{< ref "../media/#how-kairos-uses-libp2p" >}} "Media") in the [Media Section]({{< ref "../media" >}} "Media")
 {{% /alert %}}
 
 ## Overview: P2P for self-coordination
@@ -27,14 +27,14 @@ Kairos creates self-coordinated, fully meshed clusters at the edge by using a co
 
 This design is made up of several components:
 
-- The Kairos base OS with support for different distribution flavors and k3s combinations (see our support matrix [here](/docs/reference/image_matrix)).
+- The Kairos base OS with support for different distribution flavors and k3s combinations (see our support matrix [here]({{< ref "../reference/image_matrix" >}})).
 - A Virtual private network interface ([EdgeVPN](https://github.com/mudler/edgevpn) which leverages [libp2p](https://github.com/libp2p/go-libp2p)).
 - K3s/CNI configured to work with the VPN interface.
 - A shared ledger accessible to all nodes in the p2p private network.
 
 By using libp2p as the transport layer, Kairos can abstract connections between the nodes and use it as a coordination mechanism. The shared ledger serves as a cache to store additional data, such as node tokens to join nodes to the cluster or the cluster topology, and is accessible to all nodes in the P2P private network. The VPN interface is automatically configured and self-coordinated, requiring zero-configuration and no user intervention.
 
-Moreover, any application at the OS level can use P2P functionalities by using Virtual IPs within the VPN. The user only needs to provide a generated shared token containing OTP seeds for rendezvous points used during connection bootstrapping between the peers. It's worth noting that the VPN is optional, and the shared ledger can be used to coordinate and set up other forms of networking between the cluster nodes, such as KubeVIP. (See this example [here](/docs/examples/multi-node-p2p-ha-kubevip))
+Moreover, any application at the OS level can use P2P functionalities by using Virtual IPs within the VPN. The user only needs to provide a generated shared token containing OTP seeds for rendezvous points used during connection bootstrapping between the peers. It's worth noting that the VPN is optional, and the shared ledger can be used to coordinate and set up other forms of networking between the cluster nodes, such as KubeVIP. (See this example [here]({{< ref "../examples/multi-node-p2p-ha-kubevip" >}}))
 
 ## Implementation
 
@@ -88,7 +88,7 @@ Nonetheless, these tradeoffs can be overcome, and new features can be added due 
 - The p2p layer is decentralized and can span across different networks by using DHT and a bootstrap server
 - Self-coordination simplifies the provisioning experience
 - Internal cluster traffic can also be offloaded to other mechanisms if network performance is a prerequisite
-- For instance, with [KubeVIP](/docs/examples/multi-node-p2p-ha-kubevip), new nodes can join the network and become cluster members even after the cluster provisioning phase, making EdgeVPN a scalable solution.
+- For instance, with [KubeVIP]({{< ref "../examples/multi-node-p2p-ha-kubevip" >}}), new nodes can join the network and become cluster members even after the cluster provisioning phase, making EdgeVPN a scalable solution.
 
 ### Why a VPN ?
 
@@ -106,7 +106,7 @@ Additionally, network configuration is simplified with a VPN. Without a VPN, `et
 
 In terms of networking, a Kubernetes cluster without a VPN handles cluster IPs and networking natively without additional layers. However, with a VPN, Kubernetes network services will have Cluster IPs below the VPN. This means that all internal Kubernetes communication goes through the VPN. While the additional end-to-end encrypted network layer might add some latency, it is observed typically to be only 0-1ms in LAN. However, due to the Encryption layers, the CPU usage might be high if used for high-demanding traffic.
 
-It's also worth noting that while a VPN provides a unified network environment, it may not be necessary or appropriate for all use cases. Users can choose to opt-out of using the VPN and leverage only the coordination aspect, for example, with KubeVIP. Ultimately, the decision to use a VPN should be based on the specific needs and requirements of your Kubernetes cluster, and as such you can just use the co-ordination aspect and leverage for instance [KubeVIP](/docs/examples/multi-node-p2p-ha-kubevip).
+It's also worth noting that while a VPN provides a unified network environment, it may not be necessary or appropriate for all use cases. Users can choose to opt-out of using the VPN and leverage only the coordination aspect, for example, with KubeVIP. Ultimately, the decision to use a VPN should be based on the specific needs and requirements of your Kubernetes cluster, and as such you can just use the co-ordination aspect and leverage for instance [KubeVIP]({{< ref "../examples/multi-node-p2p-ha-kubevip" >}}).
 
 ### Packet flow
 
@@ -131,7 +131,7 @@ Assuming that we want to establish an SSH connection from Node A to Node B throu
 
 ### Controller
 
-A set of Kubernetes Native Extensions ([Entangle](/docs/reference/entangle)) provides peer-to-peer functionalities also to existing clusters by allowing to bridge connection with the same design architecture described above.
+A set of Kubernetes Native Extensions ([Entangle]({{< ref "../reference/entangle" >}})) provides peer-to-peer functionalities also to existing clusters by allowing to bridge connection with the same design architecture described above.
 
 It can be used to:
 
@@ -139,7 +139,7 @@ It can be used to:
 - Bridge external connections to cluster
 - Setup EdgeVPN as a daemonset between cluster nodes
 
-See also the Entangle [documentation](/docs/reference/entangle) to learn more about it.
+See also the Entangle [documentation]({{< ref "../reference/entangle" >}}) to learn more about it.
 
 ## Benefits
 
@@ -150,7 +150,7 @@ See also the Entangle [documentation](/docs/reference/entangle) to learn more ab
 The use of p2p technology to enable self-coordination of Kubernetes clusters in Kairos offers a number of benefits:
 
 1. **Simplified deployment**: Deploying Kubernetes clusters at the edge is greatly simplified. Users don’t need to specify any network settings or use a control management interface to set up and manage their clusters.
-1. **Easy customization**: Kairos offers a highly customizable approach to deploying Kubernetes clusters at the edge. Users can choose from a range of meta distributions, including openSUSE, Ubuntu, Alpine and [many others](/docs/reference/image_matrix), and customize the configuration of their clusters as needed.
+1. **Easy customization**: Kairos offers a highly customizable approach to deploying Kubernetes clusters at the edge. Users can choose from a range of meta distributions, including openSUSE, Ubuntu, Alpine and [many others]({{< ref "../reference/image_matrix" >}}), and customize the configuration of their clusters as needed.
 1. **Automatic coordination**: With Kairos, the coordination of Kubernetes clusters is completely automated. The p2p network is used as a coordination mechanism for the nodes, allowing them to communicate and coordinate with each other without the need for any external management interface. This means that users can set up and manage their Kubernetes clusters at the edge with minimal effort, freeing up their time to focus on other tasks.
 1. **Secure and replicated**: The use of rendezvous points and a shared ledger, encrypted with AES and rotated via OTP, ensures that the p2p network is secure and resilient. This is especially important when deploying Kubernetes clusters at the edge, where network conditions can be unpredictable.
 1. **Resilient**: Kairos ensures that the cluster remains resilient, even in the face of network disruptions or failures. By using VirtualIPs, nodes can communicate with each other without the need for static IPs, and the cluster's etcd database remains unaffected by any disruptions.

--- a/content/en/docs/Development/debugging-station.md
+++ b/content/en/docs/Development/debugging-station.md
@@ -7,7 +7,7 @@ description: >
   Debugging station
 ---
 
-When developing or troubleshooting Kairos, it can be useful to share a local cluster with another peer. This section illustrates how to use [Entangle]({{< ref "../reference/entangle" >}}) to achieve that. We call this setup _debugging-station_.
+When developing or troubleshooting Kairos, it can be useful to share a local cluster with another peer. This section illustrates how to use [Entangle]({{< relref "../reference/entangle" >}}) to achieve that. We call this setup _debugging-station_.
 
 ## Configuration
 
@@ -18,7 +18,7 @@ This section describes the configuration step by step. If you are in a hurry, yo
 
 {{% /alert %}}
 
-When deploying a new cluster, we can use [Bundles]({{< ref "../advanced/bundles" >}}) to install the `entangle` and `cert-manager` chart automatically. We specify the bundles in the cloud config file as shown below:
+When deploying a new cluster, we can use [Bundles]({{< relref "../advanced/bundles" >}}) to install the `entangle` and `cert-manager` chart automatically. We specify the bundles in the cloud config file as shown below:
 
 ```yaml
 bundles:
@@ -62,11 +62,11 @@ spec:
 
 {{% alert title="Note" color="warning" %}}
 
-If you have already a kubernetes cluster, you can install the [Entangle]({{< ref "../reference/entangle" >}}) chart and just apply the manifest.
+If you have already a kubernetes cluster, you can install the [Entangle]({{< relref "../reference/entangle" >}}) chart and just apply the manifest.
 
 {{% /alert %}}
 
-This entanglement will expose the port `22` in the node over the mesh network with the `ssh` service UUID so we can later connect to it. Replace `___GENERATED TOKEN HERE___` with the token you previously generated with the `docker` command (check out the [documentation]({{< ref "../reference/entangle" >}}) for advanced usage).
+This entanglement will expose the port `22` in the node over the mesh network with the `ssh` service UUID so we can later connect to it. Replace `___GENERATED TOKEN HERE___` with the token you previously generated with the `docker` command (check out the [documentation]({{< relref "../reference/entangle" >}}) for advanced usage).
 
 In order to deploy the `Entanglement` automatically, we can add it to the `k3s` manifests folder in the cloud config file:
 
@@ -161,7 +161,7 @@ In this file, you can specify various settings for your debugging station. For e
 
 ## Deploy with AuroraBoot
 
-To automatically boot and install the debugging station, we can use [Auroraboot]({{< ref "../reference/auroraboot" >}}). The following example shows how to use the cloud config above with it:
+To automatically boot and install the debugging station, we can use [Auroraboot]({{< relref "../reference/auroraboot" >}}). The following example shows how to use the cloud config above with it:
 
 ```bash
 cat <<EOF | docker run --rm -i --net host quay.io/kairos/auroraboot \

--- a/content/en/docs/Development/debugging-station.md
+++ b/content/en/docs/Development/debugging-station.md
@@ -7,7 +7,7 @@ description: >
   Debugging station
 ---
 
-When developing or troubleshooting Kairos, it can be useful to share a local cluster with another peer. This section illustrates how to use [Entangle](/docs/reference/entangle) to achieve that. We call this setup _debugging-station_.
+When developing or troubleshooting Kairos, it can be useful to share a local cluster with another peer. This section illustrates how to use [Entangle]({{< ref "../reference/entangle" >}}) to achieve that. We call this setup _debugging-station_.
 
 ## Configuration
 
@@ -18,7 +18,7 @@ This section describes the configuration step by step. If you are in a hurry, yo
 
 {{% /alert %}}
 
-When deploying a new cluster, we can use [Bundles](/docs/advanced/bundles) to install the `entangle` and `cert-manager` chart automatically. We specify the bundles in the cloud config file as shown below:
+When deploying a new cluster, we can use [Bundles]({{< ref "../advanced/bundles" >}}) to install the `entangle` and `cert-manager` chart automatically. We specify the bundles in the cloud config file as shown below:
 
 ```yaml
 bundles:
@@ -62,11 +62,11 @@ spec:
 
 {{% alert title="Note" color="warning" %}}
 
-If you have already a kubernetes cluster, you can install the [Entangle](/docs/reference/entangle) chart and just apply the manifest.
+If you have already a kubernetes cluster, you can install the [Entangle]({{< ref "../reference/entangle" >}}) chart and just apply the manifest.
 
 {{% /alert %}}
 
-This entanglement will expose the port `22` in the node over the mesh network with the `ssh` service UUID so we can later connect to it. Replace `___GENERATED TOKEN HERE___` with the token you previously generated with the `docker` command (check out the [documentation](/docs/reference/entangle) for advanced usage).
+This entanglement will expose the port `22` in the node over the mesh network with the `ssh` service UUID so we can later connect to it. Replace `___GENERATED TOKEN HERE___` with the token you previously generated with the `docker` command (check out the [documentation]({{< ref "../reference/entangle" >}}) for advanced usage).
 
 In order to deploy the `Entanglement` automatically, we can add it to the `k3s` manifests folder in the cloud config file:
 
@@ -161,7 +161,7 @@ In this file, you can specify various settings for your debugging station. For e
 
 ## Deploy with AuroraBoot
 
-To automatically boot and install the debugging station, we can use [Auroraboot](/docs/reference/auroraboot). The following example shows how to use the cloud config above with it:
+To automatically boot and install the debugging station, we can use [Auroraboot]({{< ref "../reference/auroraboot" >}}). The following example shows how to use the cloud config above with it:
 
 ```bash
 cat <<EOF | docker run --rm -i --net host quay.io/kairos/auroraboot \

--- a/content/en/docs/Examples/_index.md
+++ b/content/en/docs/Examples/_index.md
@@ -10,8 +10,8 @@ Welcome to the examples section of the Kairos documentation! Here, you will find
 
 ## Getting Started
 
-- [Quick Start Guide]({{< ref "../Getting started" >}}): This guide will walk you through the process of installing Kairos and creating your first Kubernetes cluster on bare metal.
+- [Quick Start Guide]({{< relref "../Getting started" >}}): This guide will walk you through the process of installing Kairos and creating your first Kubernetes cluster on bare metal.
 
 ## Troubleshooting
 
-- [Troubleshooting common issues]({{< ref "../reference/troubleshooting" >}}): This page provides solutions to some common issues that you may encounter while using Kairos.
+- [Troubleshooting common issues]({{< relref "../reference/troubleshooting" >}}): This page provides solutions to some common issues that you may encounter while using Kairos.

--- a/content/en/docs/Examples/_index.md
+++ b/content/en/docs/Examples/_index.md
@@ -10,8 +10,8 @@ Welcome to the examples section of the Kairos documentation! Here, you will find
 
 ## Getting Started
 
-- [Quick Start Guide](/docs/getting-started): This guide will walk you through the process of installing Kairos and creating your first Kubernetes cluster on bare metal.
+- [Quick Start Guide]({{< ref "../Getting started" >}}): This guide will walk you through the process of installing Kairos and creating your first Kubernetes cluster on bare metal.
 
 ## Troubleshooting
 
-- [Troubleshooting common issues](/docs/reference/troubleshooting): This page provides solutions to some common issues that you may encounter while using Kairos.
+- [Troubleshooting common issues]({{< ref "../reference/troubleshooting" >}}): This page provides solutions to some common issues that you may encounter while using Kairos.

--- a/content/en/docs/Examples/airgap.md
+++ b/content/en/docs/Examples/airgap.md
@@ -6,7 +6,7 @@ description: >
     This section describe examples on how to use AuroraBoot and Kairos bundles to create ISOs for airgapped installs
 ---
 
-If you want to create an [airgap K3s installation](https://docs.k3s.io/installation/airgap), Kairos provides a convenient way to do so using AuroraBoot. In this guide, we will go through the process of creating a custom ISO of Kairos that contains a configuration file and a [bundle](/docs/advanced/bundles/) that executes preparatory steps after installation. The bundle will overlay new files in the system and prepare the node for having an airgapped K3s installation.
+If you want to create an [airgap K3s installation](https://docs.k3s.io/installation/airgap), Kairos provides a convenient way to do so using AuroraBoot. In this guide, we will go through the process of creating a custom ISO of Kairos that contains a configuration file and a [bundle]({{< ref "../advanced/bundles" >}}) that executes preparatory steps after installation. The bundle will overlay new files in the system and prepare the node for having an airgapped K3s installation.
 
 {{% alert title="Note" %}}
 If you already have a Kubernetes cluster, you can use the osbuilder controller to generate container images with your additional files already inside.
@@ -18,7 +18,7 @@ Docker running in the host
 
 ## Creating the Bundle
 
-First, we need to create a bundle that contains the K3s images used for the airgap installation. The bundle will place the images in the `/var/lib/rancher/k3s/agent/images` directory. The `/var/lib/rancher` is already configured as persistent by Kairos defaults and every change to that directory persist reboots. You can add additional persistent paths in the system with [the cloud config](/docs/advanced/customizing/#bind-mounts)
+First, we need to create a bundle that contains the K3s images used for the airgap installation. The bundle will place the images in the `/var/lib/rancher/k3s/agent/images` directory. The `/var/lib/rancher` is already configured as persistent by Kairos defaults and every change to that directory persist reboots. You can add additional persistent paths in the system with [the cloud config]({{< ref "../advanced/customizing#bind-mounts" >}})
 
 1. Create a new directory named `images-bundle`, and create a new file inside it called `Dockerfile`.
 2. Paste the following code into the `Dockerfile`:
@@ -89,7 +89,7 @@ k3s:
   enabled: true
 ```
 
-2. Build the ISO with [AuroraBoot](/docs/reference/auroraboot) by running the following command:
+2. Build the ISO with [AuroraBoot]({{< ref "../reference/auroraboot" >}}) by running the following command:
 
 
 ```bash
@@ -116,7 +116,7 @@ This example is also available in the [AuroraBoot repository](https://github.com
 
 ## See also
 
-- [Customize the OS image](/docs/advanced/customizing/)
-- [Live layer bundles](/docs/advanced/livelayering/)
-- [Create ISOs with Kubernetes](/docs/installation/automated/#kubernetes)
-- [Bundles reference](https://kairos.io/docs/advanced/bundles/)
+- [Customize the OS image]({{< ref "../advanced/customizing" >}})
+- [Live layer bundles]({{< ref "../advanced/livelayering" >}})
+- [Create ISOs with Kubernetes]({{< ref "../installation/automated#kubernetes" >}})
+- [Bundles reference]({{< ref "../advanced/bundles" >}})

--- a/content/en/docs/Examples/airgap.md
+++ b/content/en/docs/Examples/airgap.md
@@ -6,7 +6,7 @@ description: >
     This section describe examples on how to use AuroraBoot and Kairos bundles to create ISOs for airgapped installs
 ---
 
-If you want to create an [airgap K3s installation](https://docs.k3s.io/installation/airgap), Kairos provides a convenient way to do so using AuroraBoot. In this guide, we will go through the process of creating a custom ISO of Kairos that contains a configuration file and a [bundle]({{< ref "../advanced/bundles" >}}) that executes preparatory steps after installation. The bundle will overlay new files in the system and prepare the node for having an airgapped K3s installation.
+If you want to create an [airgap K3s installation](https://docs.k3s.io/installation/airgap), Kairos provides a convenient way to do so using AuroraBoot. In this guide, we will go through the process of creating a custom ISO of Kairos that contains a configuration file and a [bundle]({{< relref "../advanced/bundles" >}}) that executes preparatory steps after installation. The bundle will overlay new files in the system and prepare the node for having an airgapped K3s installation.
 
 {{% alert title="Note" %}}
 If you already have a Kubernetes cluster, you can use the osbuilder controller to generate container images with your additional files already inside.
@@ -18,7 +18,7 @@ Docker running in the host
 
 ## Creating the Bundle
 
-First, we need to create a bundle that contains the K3s images used for the airgap installation. The bundle will place the images in the `/var/lib/rancher/k3s/agent/images` directory. The `/var/lib/rancher` is already configured as persistent by Kairos defaults and every change to that directory persist reboots. You can add additional persistent paths in the system with [the cloud config]({{< ref "../advanced/customizing#bind-mounts" >}})
+First, we need to create a bundle that contains the K3s images used for the airgap installation. The bundle will place the images in the `/var/lib/rancher/k3s/agent/images` directory. The `/var/lib/rancher` is already configured as persistent by Kairos defaults and every change to that directory persist reboots. You can add additional persistent paths in the system with [the cloud config]({{< relref "../advanced/customizing#bind-mounts" >}})
 
 1. Create a new directory named `images-bundle`, and create a new file inside it called `Dockerfile`.
 2. Paste the following code into the `Dockerfile`:
@@ -89,7 +89,7 @@ k3s:
   enabled: true
 ```
 
-2. Build the ISO with [AuroraBoot]({{< ref "../reference/auroraboot" >}}) by running the following command:
+2. Build the ISO with [AuroraBoot]({{< relref "../reference/auroraboot" >}}) by running the following command:
 
 
 ```bash
@@ -116,7 +116,7 @@ This example is also available in the [AuroraBoot repository](https://github.com
 
 ## See also
 
-- [Customize the OS image]({{< ref "../advanced/customizing" >}})
-- [Live layer bundles]({{< ref "../advanced/livelayering" >}})
-- [Create ISOs with Kubernetes]({{< ref "../installation/automated#kubernetes" >}})
-- [Bundles reference]({{< ref "../advanced/bundles" >}})
+- [Customize the OS image]({{< relref "../advanced/customizing" >}})
+- [Live layer bundles]({{< relref "../advanced/livelayering" >}})
+- [Create ISOs with Kubernetes]({{< relref "../installation/automated#kubernetes" >}})
+- [Bundles reference]({{< relref "../advanced/bundles" >}})

--- a/content/en/docs/Examples/bundles.md
+++ b/content/en/docs/Examples/bundles.md
@@ -6,7 +6,7 @@ description: >
     This section describe examples on how to use a Kairos bundle to deploy MetalLB on top of K3s
 ---
 
-Welcome to the guide on setting up MetalLB on a Kairos cluster with K3s! This tutorial will walk you through the steps of using a Kairos [bundle]({{< ref "../advanced/bundles" >}}) to automatically configure MetalLB on your local network with an IP range of `192.168.1.10-192.168.1.20`. Check out the [MetalLB]({{< ref "../examples/metallb" >}}) example to configure it without a [bundle]({{< ref "../advanced/bundles" >}}).
+Welcome to the guide on setting up MetalLB on a Kairos cluster with K3s! This tutorial will walk you through the steps of using a Kairos [bundle]({{< relref "../advanced/bundles" >}}) to automatically configure MetalLB on your local network with an IP range of `192.168.1.10-192.168.1.20`. Check out the [MetalLB]({{< relref "../examples/metallb" >}}) example to configure it without a [bundle]({{< relref "../advanced/bundles" >}}).
 
 For those unfamiliar with [MetalLB](https://metallb.universe.tf/), it is an open-source load balancer implementation for bare metal Kubernetes clusters that utilizes standard routing protocols. When used with K3s on Kairos, it provides load balancing capabilities and helps manage IP addresses within a cluster. 
 
@@ -20,7 +20,7 @@ Before we begin, you will need to have the following:
 
 ## Installation
 
-1. Follow the [Installation]({{< ref "../installation" >}}) documentation for Kairos.
+1. Follow the [Installation]({{< relref "../installation" >}}) documentation for Kairos.
 1. Use the following cloud configuration file when setting up Kairos:
 
 ```yaml
@@ -54,6 +54,6 @@ metallb:
 There are a few key points to note in the configuration file:
 
 - The `metallb` block is provided by the MetalLB bundle and allows us to specify the version of MetalLB that we want to deploy, as well as the `address_pool` available for our services.
-- The `bundles` block enables the `run` [bundle]({{< ref "../advanced/bundles" >}}) type. The bundle we are using is part of the [community-bundles](https://github.com/kairos-io/community-bundles) repository.
+- The `bundles` block enables the `run` [bundle]({{< relref "../advanced/bundles" >}}) type. The bundle we are using is part of the [community-bundles](https://github.com/kairos-io/community-bundles) repository.
 
-And that's it! With these steps, you should now have MetalLB configured and ready to use on your Kairos cluster. If you have any questions or run into any issues, don't hesitate to check out the [bundle documentation]({{< ref "../advanced/bundles" >}}) or reach out to the community for support.
+And that's it! With these steps, you should now have MetalLB configured and ready to use on your Kairos cluster. If you have any questions or run into any issues, don't hesitate to check out the [bundle documentation]({{< relref "../advanced/bundles" >}}) or reach out to the community for support.

--- a/content/en/docs/Examples/bundles.md
+++ b/content/en/docs/Examples/bundles.md
@@ -6,7 +6,7 @@ description: >
     This section describe examples on how to use a Kairos bundle to deploy MetalLB on top of K3s
 ---
 
-Welcome to the guide on setting up MetalLB on a Kairos cluster with K3s! This tutorial will walk you through the steps of using a Kairos [bundle](/docs/advanced/bundles) to automatically configure MetalLB on your local network with an IP range of `192.168.1.10-192.168.1.20`. Check out the [MetalLB](/docs/examples/metallb) example to configure it without a [bundle](/docs/advanced/bundles).
+Welcome to the guide on setting up MetalLB on a Kairos cluster with K3s! This tutorial will walk you through the steps of using a Kairos [bundle]({{< ref "../advanced/bundles" >}}) to automatically configure MetalLB on your local network with an IP range of `192.168.1.10-192.168.1.20`. Check out the [MetalLB]({{< ref "../examples/metallb" >}}) example to configure it without a [bundle]({{< ref "../advanced/bundles" >}}).
 
 For those unfamiliar with [MetalLB](https://metallb.universe.tf/), it is an open-source load balancer implementation for bare metal Kubernetes clusters that utilizes standard routing protocols. When used with K3s on Kairos, it provides load balancing capabilities and helps manage IP addresses within a cluster. 
 
@@ -20,7 +20,7 @@ Before we begin, you will need to have the following:
 
 ## Installation
 
-1. Follow the [Installation](/docs/installation) documentation for Kairos.
+1. Follow the [Installation]({{< ref "../installation" >}}) documentation for Kairos.
 1. Use the following cloud configuration file when setting up Kairos:
 
 ```yaml
@@ -54,6 +54,6 @@ metallb:
 There are a few key points to note in the configuration file:
 
 - The `metallb` block is provided by the MetalLB bundle and allows us to specify the version of MetalLB that we want to deploy, as well as the `address_pool` available for our services.
-- The `bundles` block enables the `run` [bundle](/docs/advanced/bundles) type. The bundle we are using is part of the [community-bundles](https://github.com/kairos-io/community-bundles) repository.
+- The `bundles` block enables the `run` [bundle]({{< ref "../advanced/bundles" >}}) type. The bundle we are using is part of the [community-bundles](https://github.com/kairos-io/community-bundles) repository.
 
-And that's it! With these steps, you should now have MetalLB configured and ready to use on your Kairos cluster. If you have any questions or run into any issues, don't hesitate to check out the [bundle documentation](/docs/advanced/bundles) or reach out to the community for support.
+And that's it! With these steps, you should now have MetalLB configured and ready to use on your Kairos cluster. If you have any questions or run into any issues, don't hesitate to check out the [bundle documentation]({{< ref "../advanced/bundles" >}}) or reach out to the community for support.

--- a/content/en/docs/Examples/core.md
+++ b/content/en/docs/Examples/core.md
@@ -8,11 +8,11 @@ description: >
 
 Kairos is a powerful, open-source meta-distribution that allows you to easily deploy and manage nodes on your Immutable infrastructure.
 
-One key feature of Kairos is the use of its core images, which are released as part of the [kairos-io/kairos](https://github.com/kairos-io/kairos) repository and can be found in the releases section. These core images serve as the foundation for creating [downstream images]({{< ref "../advanced/customizing/" >}}) or as an installer for deploying other images during the installation process. In this guide, we'll take a closer look at using Kairos core images as an installer to deploy other container images.
+One key feature of Kairos is the use of its core images, which are released as part of the [kairos-io/kairos](https://github.com/kairos-io/kairos) repository and can be found in the releases section. These core images serve as the foundation for creating [downstream images]({{< relref "../advanced/customizing/" >}}) or as an installer for deploying other images during the installation process. In this guide, we'll take a closer look at using Kairos core images as an installer to deploy other container images.
 
 ## Getting started
 
-To begin using Kairos core images as an installer, you'll need to start by using the artifacts from the [Kairos core](https://github.com/kairos-io/kairos/releases) repository. These images do not include the Kubernetes engine, so you'll need to configure the container image you want to deploy in the `install.image` field of your cloud config file. A list of available images can be found in [our support matrix]({{< ref "../reference/image_matrix/" >}}).
+To begin using Kairos core images as an installer, you'll need to start by using the artifacts from the [Kairos core](https://github.com/kairos-io/kairos/releases) repository. These images do not include the Kubernetes engine, so you'll need to configure the container image you want to deploy in the `install.image` field of your cloud config file. A list of available images can be found in [our support matrix]({{< relref "../reference/image_matrix/" >}}).
 
 For example, let's say you want to use an image from the provider-kairos repository. Your cloud config file might look something like this:
 
@@ -23,7 +23,7 @@ install:
  image: "docker:quay.io/kairos/kairos-opensuse-leap:v1.4.0-k3sv1.26.0-k3s1"
 ```
 
-Once you've chosen your image, you can move on to the installation process by following the steps outlined in our [Installation]({{< ref "../installation/" >}}) documentation.
+Once you've chosen your image, you can move on to the installation process by following the steps outlined in our [Installation]({{< relref "../installation/" >}}) documentation.
 
 For example, a full cloud-config might look like this:
 
@@ -52,9 +52,9 @@ k3s:
 
 As you move through the installation process, there are a few key points to keep in mind when configuring your cloud config file:
 
-- We set `install.image` to the container image that we want to deploy. This can be an image from [our support matrix]({{< ref "../reference/image_matrix" >}}), a [custom image]({{< ref "../advanced/customizing" >}}) or an [image from scratch]({{< ref "../reference/build-from-scratch" >}}).
+- We set `install.image` to the container image that we want to deploy. This can be an image from [our support matrix]({{< relref "../reference/image_matrix" >}}), a [custom image]({{< relref "../advanced/customizing" >}}) or an [image from scratch]({{< relref "../reference/build-from-scratch" >}}).
 - After the installation is complete, the configuration in the `k3s` block will take effect. This is because after the installation, the system will boot into the image specified in the `install.image` field, which in the example above is an image with the Kairos K3s provider, as such the configuration in the k3s block will become active.
 
 With these steps, you should now be able to use Kairos core images as an installer to deploy other container images. The process is straightforward and gives you the flexibility to customize your deployments and build custom images as needed.
 
-You can also refer our [troubleshooting]({{< ref "../reference/troubleshooting" >}}) document if you are facing any issue while following the installation process.
+You can also refer our [troubleshooting]({{< relref "../reference/troubleshooting" >}}) document if you are facing any issue while following the installation process.

--- a/content/en/docs/Examples/core.md
+++ b/content/en/docs/Examples/core.md
@@ -8,11 +8,11 @@ description: >
 
 Kairos is a powerful, open-source meta-distribution that allows you to easily deploy and manage nodes on your Immutable infrastructure.
 
-One key feature of Kairos is the use of its core images, which are released as part of the [kairos-io/kairos](https://github.com/kairos-io/kairos) repository and can be found in the releases section. These core images serve as the foundation for creating [downstream images](/docs/advanced/customizing) or as an installer for deploying other images during the installation process. In this guide, we'll take a closer look at using Kairos core images as an installer to deploy other container images.
+One key feature of Kairos is the use of its core images, which are released as part of the [kairos-io/kairos](https://github.com/kairos-io/kairos) repository and can be found in the releases section. These core images serve as the foundation for creating [downstream images]({{< ref "../advanced/customizing/" >}}) or as an installer for deploying other images during the installation process. In this guide, we'll take a closer look at using Kairos core images as an installer to deploy other container images.
 
 ## Getting started
 
-To begin using Kairos core images as an installer, you'll need to start by using the artifacts from the [Kairos core](https://github.com/kairos-io/kairos/releases) repository. These images do not include the Kubernetes engine, so you'll need to configure the container image you want to deploy in the `install.image` field of your cloud config file. A list of available images can be found in [our support matrix](/docs/reference/image_matrix).
+To begin using Kairos core images as an installer, you'll need to start by using the artifacts from the [Kairos core](https://github.com/kairos-io/kairos/releases) repository. These images do not include the Kubernetes engine, so you'll need to configure the container image you want to deploy in the `install.image` field of your cloud config file. A list of available images can be found in [our support matrix]({{< ref "../reference/image_matrix/" >}}).
 
 For example, let's say you want to use an image from the provider-kairos repository. Your cloud config file might look something like this:
 
@@ -23,7 +23,7 @@ install:
  image: "docker:quay.io/kairos/kairos-opensuse-leap:v1.4.0-k3sv1.26.0-k3s1"
 ```
 
-Once you've chosen your image, you can move on to the installation process by following the steps outlined in our [Installation](/docs/installation) documentation.
+Once you've chosen your image, you can move on to the installation process by following the steps outlined in our [Installation]({{< ref "../installation/" >}}) documentation.
 
 For example, a full cloud-config might look like this:
 
@@ -52,9 +52,9 @@ k3s:
 
 As you move through the installation process, there are a few key points to keep in mind when configuring your cloud config file:
 
-- We set `install.image` to the container image that we want to deploy. This can be an image from [our support matrix](/docs/reference/image_matrix), a [custom image](/docs/advanced/customizing) or an [image from scratch](/docs/reference/build-from-scratch).
+- We set `install.image` to the container image that we want to deploy. This can be an image from [our support matrix]({{< ref "../reference/image_matrix" >}}), a [custom image]({{< ref "../advanced/customizing" >}}) or an [image from scratch]({{< ref "../reference/build-from-scratch" >}}).
 - After the installation is complete, the configuration in the `k3s` block will take effect. This is because after the installation, the system will boot into the image specified in the `install.image` field, which in the example above is an image with the Kairos K3s provider, as such the configuration in the k3s block will become active.
 
 With these steps, you should now be able to use Kairos core images as an installer to deploy other container images. The process is straightforward and gives you the flexibility to customize your deployments and build custom images as needed.
 
-You can also refer our [troubleshoot](/docs/reference/troubleshooting) document if you are facing any issue while following the installation process.
+You can also refer our [troubleshooting]({{< ref "../reference/troubleshooting" >}}) document if you are facing any issue while following the installation process.

--- a/content/en/docs/Examples/localai.md
+++ b/content/en/docs/Examples/localai.md
@@ -19,7 +19,7 @@ But first, what is [LocalAI](https://github.com/go-skynet/LocalAI)?
 LocalAI is a self-hosted, community-driven simple local OpenAI-compatible API written in go. Can be used as a drop-in replacement for OpenAI, running on CPU with consumer-grade hardware. Supports ggml compatible models, for instance: LLaMA, alpaca, gpt4all, vicuna, koala, gpt4all-j, cerebras.
 This means that you can have the power of an AI model in your Edge-Kubernetes cluster, and it can all be easily done thanks to GPT4ALL models, LocalAI and Kairos!
 
-To get started, you'll need to use the [provider-kairos](https://github.com/kairos-io/provider-kairos) artifacts, which include k3s. Follow the [Installation]({{< ref "../installation" >}}) documentation, and use the following configuration:
+To get started, you'll need to use the [provider-kairos](https://github.com/kairos-io/provider-kairos) artifacts, which include k3s. Follow the [Installation]({{< relref "../installation" >}}) documentation, and use the following configuration:
 
 ```yaml
 #cloud-config

--- a/content/en/docs/Examples/localai.md
+++ b/content/en/docs/Examples/localai.md
@@ -19,7 +19,7 @@ But first, what is [LocalAI](https://github.com/go-skynet/LocalAI)?
 LocalAI is a self-hosted, community-driven simple local OpenAI-compatible API written in go. Can be used as a drop-in replacement for OpenAI, running on CPU with consumer-grade hardware. Supports ggml compatible models, for instance: LLaMA, alpaca, gpt4all, vicuna, koala, gpt4all-j, cerebras.
 This means that you can have the power of an AI model in your Edge-Kubernetes cluster, and it can all be easily done thanks to GPT4ALL models, LocalAI and Kairos!
 
-To get started, you'll need to use the [provider-kairos](https://github.com/kairos-io/provider-kairos) artifacts, which include k3s. Follow the [Installation](/docs/installation) documentation, and use the following configuration:
+To get started, you'll need to use the [provider-kairos](https://github.com/kairos-io/provider-kairos) artifacts, which include k3s. Follow the [Installation]({{< ref "../installation" >}}) documentation, and use the following configuration:
 
 ```yaml
 #cloud-config

--- a/content/en/docs/Examples/metallb.md
+++ b/content/en/docs/Examples/metallb.md
@@ -14,11 +14,11 @@ But first, let's talk a little bit about what [MetalLB](https://metallb.universe
 
 Now that you have an understanding of what we'll be working with, let's dive into the installation process.
 
-Check out the [bundle](/docs/examples/bundles) example to configure `MetalLB` with bundles. Bundles provides a streamlined way to publish and re-use configuration between nodes.
+Check out the [bundle]({{< ref "../examples/bundles" >}}) example to configure `MetalLB` with bundles. Bundles provides a streamlined way to publish and re-use configuration between nodes.
 
-To get started, you'll need to use the [provider-kairos](https://github.com/kairos-io/provider-kairos) artifacts, which include k3s. We'll be using the [k3s manifest method](/docs/reference/configuration#kubernetes-manifests) to deploy MetalLB.
+To get started, you'll need to use the [provider-kairos](https://github.com/kairos-io/provider-kairos) artifacts, which include k3s. We'll be using the [k3s manifest method]({{< ref "../reference/configuration#kubernetes-manifests" >}}) to deploy MetalLB.
 
-Follow the [Installation](/docs/installation) documentation, and use the following cloud config file with Kairos:
+Follow the [Installation]({{< ref "../installation" >}}) documentation, and use the following cloud config file with Kairos:
 
 ```yaml
 #cloud-config
@@ -79,7 +79,7 @@ write_files:
 There are a few things to note in this configuration file:
 
 - In the `k3s` block, we use the `--disable` flag to disable `traefik` and `servicelb`, which are the default load balancers for k3s.
-- In the `write_files` block, we write manifests (in `/var/lib/rancher/k3s/server/manifests/` see [docs](/docs/reference/configuration#kubernetes-manifests)) to deploy MetalLB and configure it to use the `192.168.1.10-192.168.1.20` IP range. Make sure to choose an IP range that doesn't interfere with your local DHCP network.
+- In the `write_files` block, we write manifests (in `/var/lib/rancher/k3s/server/manifests/` see [docs]({{< ref "../reference/configuration#kubernetes-manifests" >}})) to deploy MetalLB and configure it to use the `192.168.1.10-192.168.1.20` IP range. Make sure to choose an IP range that doesn't interfere with your local DHCP network.
 
 And that's it! You should now have MetalLB and K3s set up on your Kairos node.
 

--- a/content/en/docs/Examples/metallb.md
+++ b/content/en/docs/Examples/metallb.md
@@ -14,11 +14,11 @@ But first, let's talk a little bit about what [MetalLB](https://metallb.universe
 
 Now that you have an understanding of what we'll be working with, let's dive into the installation process.
 
-Check out the [bundle]({{< ref "../examples/bundles" >}}) example to configure `MetalLB` with bundles. Bundles provides a streamlined way to publish and re-use configuration between nodes.
+Check out the [bundle]({{< relref "../examples/bundles" >}}) example to configure `MetalLB` with bundles. Bundles provides a streamlined way to publish and re-use configuration between nodes.
 
-To get started, you'll need to use the [provider-kairos](https://github.com/kairos-io/provider-kairos) artifacts, which include k3s. We'll be using the [k3s manifest method]({{< ref "../reference/configuration#kubernetes-manifests" >}}) to deploy MetalLB.
+To get started, you'll need to use the [provider-kairos](https://github.com/kairos-io/provider-kairos) artifacts, which include k3s. We'll be using the [k3s manifest method]({{< relref "../reference/configuration#kubernetes-manifests" >}}) to deploy MetalLB.
 
-Follow the [Installation]({{< ref "../installation" >}}) documentation, and use the following cloud config file with Kairos:
+Follow the [Installation]({{< relref "../installation" >}}) documentation, and use the following cloud config file with Kairos:
 
 ```yaml
 #cloud-config
@@ -79,7 +79,7 @@ write_files:
 There are a few things to note in this configuration file:
 
 - In the `k3s` block, we use the `--disable` flag to disable `traefik` and `servicelb`, which are the default load balancers for k3s.
-- In the `write_files` block, we write manifests (in `/var/lib/rancher/k3s/server/manifests/` see [docs]({{< ref "../reference/configuration#kubernetes-manifests" >}})) to deploy MetalLB and configure it to use the `192.168.1.10-192.168.1.20` IP range. Make sure to choose an IP range that doesn't interfere with your local DHCP network.
+- In the `write_files` block, we write manifests (in `/var/lib/rancher/k3s/server/manifests/` see [docs]({{< relref "../reference/configuration#kubernetes-manifests" >}})) to deploy MetalLB and configure it to use the `192.168.1.10-192.168.1.20` IP range. Make sure to choose an IP range that doesn't interfere with your local DHCP network.
 
 And that's it! You should now have MetalLB and K3s set up on your Kairos node.
 

--- a/content/en/docs/Examples/multi-node-p2p-ha-kubevip.md
+++ b/content/en/docs/Examples/multi-node-p2p-ha-kubevip.md
@@ -68,7 +68,7 @@ p2p:
      master_nodes: 2
 ```
 
-When configuring the `p2p` section, start by adding your desired `network_token` under the p2p configuration in the cloud-config file. To generate a network token, see [documentation]({{< ref "../installation/p2p#network_token" >}}).
+When configuring the `p2p` section, start by adding your desired `network_token` under the p2p configuration in the cloud-config file. To generate a network token, see [documentation]({{< relref "../installation/p2p#network_token" >}}).
 
 Next, set up an Elastic IP (`kubevip.eip`) with a free IP in your network. KubeVIP will advertise this IP, so make sure to select an IP that is available for use on your network.
 

--- a/content/en/docs/Examples/multi-node-p2p-ha-kubevip.md
+++ b/content/en/docs/Examples/multi-node-p2p-ha-kubevip.md
@@ -68,7 +68,7 @@ p2p:
      master_nodes: 2
 ```
 
-When configuring the `p2p` section, start by adding your desired `network_token` under the p2p configuration in the cloud-config file. To generate a network token, see [documentation](/docs/installation/p2p/#network_token).
+When configuring the `p2p` section, start by adding your desired `network_token` under the p2p configuration in the cloud-config file. To generate a network token, see [documentation]({{< ref "../installation/p2p#network_token" >}}).
 
 Next, set up an Elastic IP (`kubevip.eip`) with a free IP in your network. KubeVIP will advertise this IP, so make sure to select an IP that is available for use on your network.
 

--- a/content/en/docs/Examples/multi-node-p2p-ha.md
+++ b/content/en/docs/Examples/multi-node-p2p-ha.md
@@ -16,7 +16,7 @@ Feedback and bug reports are welcome, as we are improving the p2p aspects of Kai
 
 To enable automatic HA rollout, enable the `p2p.auto.ha.enable` option in your cloud-config, and set up a number of `master_nodes`. The number of `master_nodes` is the number of additional masters in addition to the initial HA role. There will always be a minimum of 1 master, which is already taken into account. For example, setting up `master_nodes` to two will result in a total of 3 master nodes in your cluster.
 
-To make this process even easier, Kairos automatically configures each node in the cluster from a unique cloud-config. This way, you don't have to manually configure each node, but provide instead a config file for all of the machines during [Installation]({{< ref "../installation/" >}}).
+To make this process even easier, Kairos automatically configures each node in the cluster from a unique cloud-config. This way, you don't have to manually configure each node, but provide instead a config file for all of the machines during [Installation]({{< relref "../installation/" >}}).
 
 Here is an example of what your cloud-config might look like:
 ```yaml
@@ -57,5 +57,5 @@ p2p:
      master_nodes: 2
 ```
 
-Note: In order for the automatic HA rollout to work, you need to generate a network token. You can find more information on how to do this in the [dedicated section]({{< ref "../installation/p2p#network_token" >}}).
+Note: In order for the automatic HA rollout to work, you need to generate a network token. You can find more information on how to do this in the [dedicated section]({{< relref "../installation/p2p#network_token" >}}).
 

--- a/content/en/docs/Examples/multi-node-p2p-ha.md
+++ b/content/en/docs/Examples/multi-node-p2p-ha.md
@@ -16,7 +16,7 @@ Feedback and bug reports are welcome, as we are improving the p2p aspects of Kai
 
 To enable automatic HA rollout, enable the `p2p.auto.ha.enable` option in your cloud-config, and set up a number of `master_nodes`. The number of `master_nodes` is the number of additional masters in addition to the initial HA role. There will always be a minimum of 1 master, which is already taken into account. For example, setting up `master_nodes` to two will result in a total of 3 master nodes in your cluster.
 
-To make this process even easier, Kairos automatically configures each node in the cluster from a unique cloud-config. This way, you don't have to manually configure each node, but provide instead a config file for all of the machines during [Installation](/docs/installation).
+To make this process even easier, Kairos automatically configures each node in the cluster from a unique cloud-config. This way, you don't have to manually configure each node, but provide instead a config file for all of the machines during [Installation]({{< ref "../installation/" >}}).
 
 Here is an example of what your cloud-config might look like:
 ```yaml
@@ -57,5 +57,5 @@ p2p:
      master_nodes: 2
 ```
 
-Note: In order for the automatic HA rollout to work, you need to generate a network token. You can find more information on how to do this in the [dedicated section](/docs/installation/p2p/#network_token).
+Note: In order for the automatic HA rollout to work, you need to generate a network token. You can find more information on how to do this in the [dedicated section]({{< ref "../installation/p2p#network_token" >}}).
 

--- a/content/en/docs/Examples/multi-node-p2p.md
+++ b/content/en/docs/Examples/multi-node-p2p.md
@@ -40,7 +40,7 @@ p2p:
 
 ```
 
-To set up a multi-node P2P scenario with non-HA in Kairos, start by adding your desired `network_token` under the p2p configuration in the cloud-config file. To generate a network token, see [documentation](/docs/installation/p2p/#network_token).
+To set up a multi-node P2P scenario with non-HA in Kairos, start by adding your desired `network_token` under the p2p configuration in the cloud-config file. To generate a network token, see [documentation]({{< ref "../installation/p2p#network_token" >}}).
 
 Be sure to set `disable_dht` to true. This will ensure that coordination to discover nodes only happens on the local network.
 

--- a/content/en/docs/Examples/multi-node-p2p.md
+++ b/content/en/docs/Examples/multi-node-p2p.md
@@ -40,7 +40,7 @@ p2p:
 
 ```
 
-To set up a multi-node P2P scenario with non-HA in Kairos, start by adding your desired `network_token` under the p2p configuration in the cloud-config file. To generate a network token, see [documentation]({{< ref "../installation/p2p#network_token" >}}).
+To set up a multi-node P2P scenario with non-HA in Kairos, start by adding your desired `network_token` under the p2p configuration in the cloud-config file. To generate a network token, see [documentation]({{< relref "../installation/p2p#network_token" >}}).
 
 Be sure to set `disable_dht` to true. This will ensure that coordination to discover nodes only happens on the local network.
 

--- a/content/en/docs/Examples/multi-node.md
+++ b/content/en/docs/Examples/multi-node.md
@@ -12,7 +12,7 @@ In the example below we will use a bare metal host to provision a Kairos cluster
 
 Use the [provider-kairos](https://github.com/kairos-io/provider-kairos) artifacts which contains `k3s`.
 
-Follow the [Installation]({{< ref "../installation" >}}) documentation, and use the following cloud config file with Kairos for the master and worker:
+Follow the [Installation]({{< relref "../installation" >}}) documentation, and use the following cloud config file with Kairos for the master and worker:
 
 {{< tabpane text=true right=true  >}}
 {{% tab header="server" %}}

--- a/content/en/docs/Examples/multi-node.md
+++ b/content/en/docs/Examples/multi-node.md
@@ -12,7 +12,7 @@ In the example below we will use a bare metal host to provision a Kairos cluster
 
 Use the [provider-kairos](https://github.com/kairos-io/provider-kairos) artifacts which contains `k3s`.
 
-Follow the [Installation](/docs/installation) documentation, and use the following cloud config file with Kairos for the master and worker:
+Follow the [Installation]({{< ref "../installation" >}}) documentation, and use the following cloud config file with Kairos for the master and worker:
 
 {{< tabpane text=true right=true  >}}
 {{% tab header="server" %}}

--- a/content/en/docs/Examples/p2p_e2e.md
+++ b/content/en/docs/Examples/p2p_e2e.md
@@ -19,14 +19,14 @@ Deploying Kubernetes at the Edge can be a complex and time-consuming process, es
 To leverage p2p self-coordination capabilities of Kairos, you will need to configure the `network_token` under the `p2p` configuration block in your cloud-config file. Once you have set this, Kairos will handle the configuration of each node.
 
 {{% alert title="Note" %}}
-You can see this example live in the [Kairos and libp2p video]({{< ref "docs/media/#how-kairos-uses-libp2p" >}} "Media") in the [Media Section]({{< ref "docs/media" >}} "Media")
+You can see this example live in the [Kairos and libp2p video]({{< relref "docs/media/#how-kairos-uses-libp2p" >}} "Media") in the [Media Section]({{< relref "docs/media" >}} "Media")
 {{% /alert %}}
 
 ## Description
 
 In the following example we are going to bootstrap a new multi-node, single cluster with Kairos. We will use at least 2 nodes, one as a master and one as a worker. Note how we don't specify any role, or either pin any IP in the following configurations.
 
-We will first create a cloud config file for our deployment, and then run [AuroraBoot]({{< ref "../reference/auroraboot" >}}) locally. We then start 2 VMs configured for netbooting. 
+We will first create a cloud config file for our deployment, and then run [AuroraBoot]({{< relref "../reference/auroraboot" >}}) locally. We then start 2 VMs configured for netbooting. 
 
 ## Prepare your `cloud-config` file
 
@@ -102,7 +102,7 @@ ssh_authorized_keys:
 
 ## Provisioning with AuroraBoot
 
-We now can run [AuroraBoot]({{< ref "../reference/auroraboot" >}}) with `quay.io/kairos/kairos-opensuse-leap:v1.5.1-k3sv1.21.14-k3s1` to provision `openSUSE Leap` machines with `k3s 1.21.14` and Kairos `1.5.1`. 
+We now can run [AuroraBoot]({{< relref "../reference/auroraboot" >}}) with `quay.io/kairos/kairos-opensuse-leap:v1.5.1-k3sv1.21.14-k3s1` to provision `openSUSE Leap` machines with `k3s 1.21.14` and Kairos `1.5.1`. 
 
 AuroraBoot takes `cloud-config` files also from _STDIN_, so we will pipe the configuration file to it, and specify the container image that we want to use for our nodes:
 
@@ -135,7 +135,7 @@ EOF
 
 ## Booting and access the cluster
 
-Start the Machines (VM, or baremetal) with Netboot ( see also [here]({{< ref "../reference/auroraboot#3-start-nodes" >}}) ) and wait for the installation to finish.
+Start the Machines (VM, or baremetal) with Netboot ( see also [here]({{< relref "../reference/auroraboot#3-start-nodes" >}}) ) and wait for the installation to finish.
 
 Afterward, you should be able to ssh to one of the machines and be able to use your Kubernetes cluster:
 
@@ -148,7 +148,7 @@ $ KUBECONFIG=kubeconfig k9s
 
 ## Notes
 
-By default, the Kubernetes API endpoint is not exposed outside the VPN. This is an opinionated configuration from Kairos. To check out configurations without VPN, see also [the KubeVIP example]({{< ref "../examples/multi-node-p2p-ha-kubevip" >}}).
+By default, the Kubernetes API endpoint is not exposed outside the VPN. This is an opinionated configuration from Kairos. To check out configurations without VPN, see also [the KubeVIP example]({{< relref "../examples/multi-node-p2p-ha-kubevip" >}}).
 
 ## Troubleshooing
 
@@ -161,5 +161,5 @@ $ journalctl -fu kairos-agent
 
 ## See also
 
-- [Installation with p2p]({{< ref "../installation/p2p" >}})
-- [P2P Architecture]({{< ref "../architecture/network" >}})
+- [Installation with p2p]({{< relref "../installation/p2p" >}})
+- [P2P Architecture]({{< relref "../architecture/network" >}})

--- a/content/en/docs/Examples/p2p_e2e.md
+++ b/content/en/docs/Examples/p2p_e2e.md
@@ -26,7 +26,7 @@ You can see this example live in the [Kairos and libp2p video]({{< ref "docs/med
 
 In the following example we are going to bootstrap a new multi-node, single cluster with Kairos. We will use at least 2 nodes, one as a master and one as a worker. Note how we don't specify any role, or either pin any IP in the following configurations.
 
-We will first create a cloud config file for our deployment, and then run [AuroraBoot](/docs/reference/auroraboot) locally. We then start 2 VMs configured for netbooting. 
+We will first create a cloud config file for our deployment, and then run [AuroraBoot]({{< ref "../reference/auroraboot" >}}) locally. We then start 2 VMs configured for netbooting. 
 
 ## Prepare your `cloud-config` file
 
@@ -102,7 +102,7 @@ ssh_authorized_keys:
 
 ## Provisioning with AuroraBoot
 
-We now can run [AuroraBoot](/docs/reference/auroraboot) with `quay.io/kairos/kairos-opensuse-leap:v1.5.1-k3sv1.21.14-k3s1` to provision `openSUSE Leap` machines with `k3s 1.21.14` and Kairos `1.5.1`. 
+We now can run [AuroraBoot]({{< ref "../reference/auroraboot" >}}) with `quay.io/kairos/kairos-opensuse-leap:v1.5.1-k3sv1.21.14-k3s1` to provision `openSUSE Leap` machines with `k3s 1.21.14` and Kairos `1.5.1`. 
 
 AuroraBoot takes `cloud-config` files also from _STDIN_, so we will pipe the configuration file to it, and specify the container image that we want to use for our nodes:
 
@@ -135,7 +135,7 @@ EOF
 
 ## Booting and access the cluster
 
-Start the Machines (VM, or baremetal) with Netboot ( see also [here](/docs/reference/auroraboot/#3-start-nodes) ) and wait for the installation to finish.
+Start the Machines (VM, or baremetal) with Netboot ( see also [here]({{< ref "../reference/auroraboot#3-start-nodes" >}}) ) and wait for the installation to finish.
 
 Afterward, you should be able to ssh to one of the machines and be able to use your Kubernetes cluster:
 
@@ -148,7 +148,7 @@ $ KUBECONFIG=kubeconfig k9s
 
 ## Notes
 
-By default, the Kubernetes API endpoint is not exposed outside the VPN. This is an opinionated configuration from Kairos. To check out configurations without VPN, see also [the KubeVIP example](/docs/examples/multi-node-p2p-ha-kubevip).
+By default, the Kubernetes API endpoint is not exposed outside the VPN. This is an opinionated configuration from Kairos. To check out configurations without VPN, see also [the KubeVIP example]({{< ref "../examples/multi-node-p2p-ha-kubevip" >}}).
 
 ## Troubleshooing
 
@@ -161,5 +161,5 @@ $ journalctl -fu kairos-agent
 
 ## See also
 
-- [Installation with p2p](/docs/installation/p2p)
-- [P2P Architecture](/docs/architecture/network)
+- [Installation with p2p]({{< ref "../installation/p2p" >}})
+- [P2P Architecture]({{< ref "../architecture/network" >}})

--- a/content/en/docs/Examples/single-node-p2p.md
+++ b/content/en/docs/Examples/single-node-p2p.md
@@ -48,7 +48,7 @@ One important note is that this example requires the YAML format when editing th
 
 The above cloud-config configures the hostname, creates a new user `kairos`, and sets the `role` to `master`. Additionally, it disables DHT (distributed hash table) to make the VPN functional only within the local network and use *mDNS* for discovery. If you wish to make the VPN work across different networks, you can set `disable_dht` to `false` or unset it.
 
-The `network_token` field is a shared secret used by the nodes to coordinate with P2P. Setting a network token implies `auto.enable`. If you wish to disable it, simply set `auto.enable` to false. To generate a network token, see [documentation](/docs/installation/p2p/#network_token).
+The `network_token` field is a shared secret used by the nodes to coordinate with P2P. Setting a network token implies `auto.enable`. If you wish to disable it, simply set `auto.enable` to false. To generate a network token, see [documentation]({{< ref "../installation/p2p#network_token" >}}).
 
 Keep in mind that, this example is a minimal configuration, and you can add more options depending on your needs. The above configuration can be used as a starting point and can be customized further.
 

--- a/content/en/docs/Examples/single-node-p2p.md
+++ b/content/en/docs/Examples/single-node-p2p.md
@@ -48,7 +48,7 @@ One important note is that this example requires the YAML format when editing th
 
 The above cloud-config configures the hostname, creates a new user `kairos`, and sets the `role` to `master`. Additionally, it disables DHT (distributed hash table) to make the VPN functional only within the local network and use *mDNS* for discovery. If you wish to make the VPN work across different networks, you can set `disable_dht` to `false` or unset it.
 
-The `network_token` field is a shared secret used by the nodes to coordinate with P2P. Setting a network token implies `auto.enable`. If you wish to disable it, simply set `auto.enable` to false. To generate a network token, see [documentation]({{< ref "../installation/p2p#network_token" >}}).
+The `network_token` field is a shared secret used by the nodes to coordinate with P2P. Setting a network token implies `auto.enable`. If you wish to disable it, simply set `auto.enable` to false. To generate a network token, see [documentation]({{< relref "../installation/p2p#network_token" >}}).
 
 Keep in mind that, this example is a minimal configuration, and you can add more options depending on your needs. The above configuration can be used as a starting point and can be customized further.
 

--- a/content/en/docs/Examples/single-node.md
+++ b/content/en/docs/Examples/single-node.md
@@ -12,7 +12,7 @@ In the example below we will use a bare metal host to provision a Kairos node in
 
 Use the [provider-kairos](https://github.com/kairos-io/provider-kairos) artifacts which contains `k3s`.
 
-Follow the [Installation]({{< ref "../installation/" >}}) documentation, and use the following cloud config file with Kairos:
+Follow the [Installation]({{< relref "../installation/" >}}) documentation, and use the following cloud config file with Kairos:
 
 ```yaml
 #cloud-config
@@ -46,4 +46,4 @@ Notably:
   {{% alert title="Note" %}}
   `replace_args` replaces all arguments otherwise passed to k3s by Kairos with those supplied here. Make sure you pass all the arguments you need.
   {{% /alert %}}
-- We use `write_files` to write manifests to the default `k3s` manifest directory (`/var/lib/rancher/k3s/server/manifests/`) see [docs]({{< ref "../reference/configuration#kubernetes-manifests" >}}) to deploy `MetalLB` and configure it with the `192.168.1.10-192.168.1.20` IP range. Make sure to pick up a range which doesn't interfere with your local DHCP network.
+- We use `write_files` to write manifests to the default `k3s` manifest directory (`/var/lib/rancher/k3s/server/manifests/`) see [docs]({{< relref "../reference/configuration#kubernetes-manifests" >}}) to deploy `MetalLB` and configure it with the `192.168.1.10-192.168.1.20` IP range. Make sure to pick up a range which doesn't interfere with your local DHCP network.

--- a/content/en/docs/Examples/single-node.md
+++ b/content/en/docs/Examples/single-node.md
@@ -12,7 +12,7 @@ In the example below we will use a bare metal host to provision a Kairos node in
 
 Use the [provider-kairos](https://github.com/kairos-io/provider-kairos) artifacts which contains `k3s`.
 
-Follow the [Installation](/docs/installation) documentation, and use the following cloud config file with Kairos:
+Follow the [Installation]({{< ref "../installation/" >}}) documentation, and use the following cloud config file with Kairos:
 
 ```yaml
 #cloud-config
@@ -46,4 +46,4 @@ Notably:
   {{% alert title="Note" %}}
   `replace_args` replaces all arguments otherwise passed to k3s by Kairos with those supplied here. Make sure you pass all the arguments you need.
   {{% /alert %}}
-- We use `write_files` to write manifests to the default `k3s` manifest directory (`/var/lib/rancher/k3s/server/manifests/`) see [docs](/docs/reference/configuration#kubernetes-manifests) to deploy `MetalLB` and configure it with the `192.168.1.10-192.168.1.20` IP range. Make sure to pick up a range which doesn't interfere with your local DHCP network.
+- We use `write_files` to write manifests to the default `k3s` manifest directory (`/var/lib/rancher/k3s/server/manifests/`) see [docs]({{< ref "../reference/configuration#kubernetes-manifests" >}}) to deploy `MetalLB` and configure it with the `192.168.1.10-192.168.1.20` IP range. Make sure to pick up a range which doesn't interfere with your local DHCP network.

--- a/content/en/docs/Getting started/_index.md
+++ b/content/en/docs/Getting started/_index.md
@@ -12,7 +12,7 @@ If you prefer video format, you can also watch our [Introduction to Kairos video
 
 Ready to launch your Kubernetes cluster with ease? With Kairos, deployment is a breeze! Simply download the pre-packaged artifacts, boot up on a VM or bare metal, and let Kairos handle the rest. Whether you're a Linux or Windows user, our quickstart guide will have you up and running in no time. Kairos can build a Kubernetes cluster for you with just a few simple steps!
 
-The goal of this quickstart is to help you quickly and easily deploy a Kubernetes cluster using Kairos releases. With Kairos, you can easily build a k3s cluster in a VM, or a baremetal using our pre-packaged artifacts, even if you don't already have a cluster. This process can also be used on bare metal hosts with some configuration adjustments. Check out our documentation further for more detailed instructions and [examples](/docs/examples).
+The goal of this quickstart is to help you quickly and easily deploy a Kubernetes cluster using Kairos releases. With Kairos, you can easily build a k3s cluster in a VM, or a baremetal using our pre-packaged artifacts, even if you don't already have a cluster. This process can also be used on bare metal hosts with some configuration adjustments. Check out our documentation further for more detailed instructions and [examples]({{< ref "../examples" >}}).
 
 To create a Kubernetes cluster with Kairos, the only thing needed is one or more machines that will become the Kubernetes nodes. No previously existing clusters is needed.
 
@@ -31,18 +31,18 @@ Once the installation is complete, you can begin using your Kubernetes cluster.
 1. Select the latest release and download the assets of your flavor. For example,
    pick the [kairos-opensuse-leap-{{<providerVersion>}}-{{<k3sVersion>}}.iso](https://github.com/kairos-io/provider-kairos/releases/download/{{<providerVersion>}}/kairos-opensuse-leap-{{<providerVersion>}}-{{<k3sVersion>}}.iso)
    ISO file for the openSUSE based version, where `{{< k3sVersion >}}` in the name is the `k3s` version and `{{< providerVersion >}}` is the Kairos one to deploy on a VM.
-1. You can also use [netboot](/docs/installation/netboot) to boot Kairos over the network
+1. You can also use [netboot]({{< ref "../installation/netboot" >}}) to boot Kairos over the network
 
 {{% alert title="Note" %}}
 The releases in the [kairos-io/kairos](https://github.com/kairos-io/kairos/releases) repository are the Kairos
 core images that ship **without** K3s and P2P full-mesh functionalities; Core images can be used as a
-generic installer to [deploy container images](/docs/examples/core).
+generic installer to [deploy container images]({{< ref "../examples/core" >}}).
 
 The releases in [kairos-io/provider-kairos](https://github.com/kairos-io/provider-kairos/releases)
 **contains** already k3s and P2P full-mesh instead. These options need to be explicitly enabled.
 In follow-up releases, _k3s-only_ artifacts will also be available.
 
-See [Image Matrix Support](/docs/reference/image_matrix) for additional supported images and kernels.
+See [Image Matrix Support]({{< ref "../reference/image_matrix" >}}) for additional supported images and kernels.
 
 {{% /alert %}}
 
@@ -163,11 +163,11 @@ Here are some additional helpful tips depending on the physical/virtual machine 
 After booting you'll be greeted with a GRUB boot menu with multiple options.
 The option you choose will depend on how you plan to install Kairos:
 
-- The first entry will boot into installation with a QR code or [WebUI](/docs/installation/webui),
+- The first entry will boot into installation with a QR code or [WebUI]({{< ref "../installation/webui" >}}),
   which we'll cover in the next step.
-- The second entry will boot into [Manual installation mode](/docs/installation/manual),
+- The second entry will boot into [Manual installation mode]({{< ref "../installation/manual" >}}),
   where you can install Kairos manually using the console.
-- The third boot option boots into [Interactive installation mode](/docs/installation/interactive),
+- The third boot option boots into [Interactive installation mode]({{< ref "../installation/interactive" >}}),
   where you can use the terminal host to drive the installation and skip the Configuration and Provisioning step.
 
 To begin the installation process, select the first entry and let the machine boot. Eventually, a QR code will be printed on the screen. Follow the next step in the documentation to complete the installation.
@@ -178,10 +178,10 @@ To begin the installation process, select the first entry and let the machine bo
 
 After booting up the ISO, the machine will wait for you to provide configuration details before continuing with the installation process. There are different ways to provide these details:
 
-- Use the [WebUI](/docs/installation/webui) to continue the installation.
+- Use the [WebUI]({{< ref "../installation/webui" >}}) to continue the installation.
 - Serve the configuration via QR code.
-- Connect to the machine via [SSH](/docs/installation/manual) and start the installation process with a configuration file ( with `kairos-agent manual-install <config>`).
-- [Use a datasource iso, or a generating a custom one](/docs/installation/automated)
+- Connect to the machine via [SSH]({{< ref "../installation/manual" >}}) and start the installation process with a configuration file ( with `kairos-agent manual-install <config>`).
+- [Use a datasource iso, or a generating a custom one]({{< ref "../installation/automated" >}})
 
 The configuration file is a YAML file with `cloud-init` syntax and additional Kairos configuration details. In this example, we'll configure the node as a single-node Kubernetes cluster using K3s. We'll also set a default password for the Kairos user and define SSH keys.
 
@@ -209,17 +209,17 @@ k3s:
 
 Save this file as config.yaml and use it to start the installation process with kairos-agent manual-install config.yaml. This will configure the node as a single-node Kubernetes cluster and set the default password and SSH keys as specified in the configuration file.
 
-[Check out the full configuration reference](/docs/reference/configuration).
+[Check out the full configuration reference]({{< ref "../reference/configuration" >}}).
 
 **Note**:
 
 - `users`: This block defines the user accounts on the node. In this example, it creates a user named `kairos` with the password `kairos` and adds two SSH keys to the user's authorized keys.
 - `k3s`: This block enables K3s on the node.
-- If you want to enable experimental P2P support, check out [P2P installation](/docs/installation/p2p)
+- If you want to enable experimental P2P support, check out [P2P installation]({{< ref "../installation/p2p" >}})
 
 {{% alert title="Note" %}}
 
-Several configurations can be added at this stage. [See the configuration reference](/docs/reference/configuration) for further reading.
+Several configurations can be added at this stage. [See the configuration reference]({{< ref "../reference/configuration" >}}) for further reading.
 
 {{% /alert %}}
 
@@ -227,7 +227,7 @@ Several configurations can be added at this stage. [See the configuration refere
 
 {{% alert title="Note" %}}
 
-You can find instructions showing how to use the Kairos CLI below. In case you prefer to install via SSH and log in to the box, see the [Manual installation](/docs/installation/manual) section or the [Interactive installation](/docs/installation/interactive) section to perform the installation manually from the console.
+You can find instructions showing how to use the Kairos CLI below. In case you prefer to install via SSH and log in to the box, see the [Manual installation]({{< ref "../installation/manual" >}}) section or the [Interactive installation]({{< ref "../installation/interactive" >}}) section to perform the installation manually from the console.
 
 {{% /alert %}}
 
@@ -303,17 +303,17 @@ The K3s `kubeconfig` file is available at `/etc/rancher/k3s/k3s.yaml`. Please re
 
 There are other ways to install Kairos:
 
-- [Automated installation](/docs/installation/automated)
-- [Manual login and installation](/docs/installation/manual)
-- [Create decentralized clusters](/docs/installation/p2p)
-- [Take over installation](/docs/installation/takeover)
-- [Installation via network](/docs/installation/netboot)
-- [Raspberry Pi](/docs/installation/raspberry)
+- [Automated installation]({{< ref "../installation/automated" >}})
+- [Manual login and installation]({{< ref "../installation/manual" >}})
+- [Create decentralized clusters]({{< ref "../installation/p2p" >}})
+- [Take over installation]({{< ref "../installation/takeover" >}})
+- [Installation via network]({{< ref "../installation/netboot" >}})
+- [Raspberry Pi]({{< ref "../installation/raspberry" >}})
 - [CAPI Lifecycle Management (TODO)]()
 
 ## What's Next?
 
-- [Upgrade nodes with Kubernetes](/docs/upgrade/kubernetes)
-- [Upgrade nodes manually](/docs/upgrade/manual)
-- [Encrypt partitions](/docs/advanced/partition_encryption)
-- [Immutable architecture](/docs/architecture/immutable)
+- [Upgrade nodes with Kubernetes]({{< ref "../upgrade/kubernetes" >}})
+- [Upgrade nodes manually]({{< ref "../upgrade/manual" >}})
+- [Encrypt partitions]({{< ref "../advanced/partition_encryption" >}})
+- [Immutable architecture]({{< ref "../architecture/immutable" >}})

--- a/content/en/docs/Getting started/_index.md
+++ b/content/en/docs/Getting started/_index.md
@@ -7,12 +7,12 @@ description: >
 ---
 
 {{% alert title="Note" %}}
-If you prefer video format, you can also watch our [Introduction to Kairos video]({{< ref "docs/media/#introduction-to-kairos" >}} "Media") on the [Media Section]({{< ref "docs/media" >}} "Media")
+If you prefer video format, you can also watch our [Introduction to Kairos video]({{< relref "docs/media/#introduction-to-kairos" >}} "Media") on the [Media Section]({{< relref "docs/media" >}} "Media")
 {{% /alert %}}
 
 Ready to launch your Kubernetes cluster with ease? With Kairos, deployment is a breeze! Simply download the pre-packaged artifacts, boot up on a VM or bare metal, and let Kairos handle the rest. Whether you're a Linux or Windows user, our quickstart guide will have you up and running in no time. Kairos can build a Kubernetes cluster for you with just a few simple steps!
 
-The goal of this quickstart is to help you quickly and easily deploy a Kubernetes cluster using Kairos releases. With Kairos, you can easily build a k3s cluster in a VM, or a baremetal using our pre-packaged artifacts, even if you don't already have a cluster. This process can also be used on bare metal hosts with some configuration adjustments. Check out our documentation further for more detailed instructions and [examples]({{< ref "../examples" >}}).
+The goal of this quickstart is to help you quickly and easily deploy a Kubernetes cluster using Kairos releases. With Kairos, you can easily build a k3s cluster in a VM, or a baremetal using our pre-packaged artifacts, even if you don't already have a cluster. This process can also be used on bare metal hosts with some configuration adjustments. Check out our documentation further for more detailed instructions and [examples]({{< relref "../examples" >}}).
 
 To create a Kubernetes cluster with Kairos, the only thing needed is one or more machines that will become the Kubernetes nodes. No previously existing clusters is needed.
 
@@ -31,18 +31,18 @@ Once the installation is complete, you can begin using your Kubernetes cluster.
 1. Select the latest release and download the assets of your flavor. For example,
    pick the [kairos-opensuse-leap-{{<providerVersion>}}-{{<k3sVersion>}}.iso](https://github.com/kairos-io/provider-kairos/releases/download/{{<providerVersion>}}/kairos-opensuse-leap-{{<providerVersion>}}-{{<k3sVersion>}}.iso)
    ISO file for the openSUSE based version, where `{{< k3sVersion >}}` in the name is the `k3s` version and `{{< providerVersion >}}` is the Kairos one to deploy on a VM.
-1. You can also use [netboot]({{< ref "../installation/netboot" >}}) to boot Kairos over the network
+1. You can also use [netboot]({{< relref "../installation/netboot" >}}) to boot Kairos over the network
 
 {{% alert title="Note" %}}
 The releases in the [kairos-io/kairos](https://github.com/kairos-io/kairos/releases) repository are the Kairos
 core images that ship **without** K3s and P2P full-mesh functionalities; Core images can be used as a
-generic installer to [deploy container images]({{< ref "../examples/core" >}}).
+generic installer to [deploy container images]({{< relref "../examples/core" >}}).
 
 The releases in [kairos-io/provider-kairos](https://github.com/kairos-io/provider-kairos/releases)
 **contains** already k3s and P2P full-mesh instead. These options need to be explicitly enabled.
 In follow-up releases, _k3s-only_ artifacts will also be available.
 
-See [Image Matrix Support]({{< ref "../reference/image_matrix" >}}) for additional supported images and kernels.
+See [Image Matrix Support]({{< relref "../reference/image_matrix" >}}) for additional supported images and kernels.
 
 {{% /alert %}}
 
@@ -163,11 +163,11 @@ Here are some additional helpful tips depending on the physical/virtual machine 
 After booting you'll be greeted with a GRUB boot menu with multiple options.
 The option you choose will depend on how you plan to install Kairos:
 
-- The first entry will boot into installation with a QR code or [WebUI]({{< ref "../installation/webui" >}}),
+- The first entry will boot into installation with a QR code or [WebUI]({{< relref "../installation/webui" >}}),
   which we'll cover in the next step.
-- The second entry will boot into [Manual installation mode]({{< ref "../installation/manual" >}}),
+- The second entry will boot into [Manual installation mode]({{< relref "../installation/manual" >}}),
   where you can install Kairos manually using the console.
-- The third boot option boots into [Interactive installation mode]({{< ref "../installation/interactive" >}}),
+- The third boot option boots into [Interactive installation mode]({{< relref "../installation/interactive" >}}),
   where you can use the terminal host to drive the installation and skip the Configuration and Provisioning step.
 
 To begin the installation process, select the first entry and let the machine boot. Eventually, a QR code will be printed on the screen. Follow the next step in the documentation to complete the installation.
@@ -178,10 +178,10 @@ To begin the installation process, select the first entry and let the machine bo
 
 After booting up the ISO, the machine will wait for you to provide configuration details before continuing with the installation process. There are different ways to provide these details:
 
-- Use the [WebUI]({{< ref "../installation/webui" >}}) to continue the installation.
+- Use the [WebUI]({{< relref "../installation/webui" >}}) to continue the installation.
 - Serve the configuration via QR code.
-- Connect to the machine via [SSH]({{< ref "../installation/manual" >}}) and start the installation process with a configuration file ( with `kairos-agent manual-install <config>`).
-- [Use a datasource iso, or a generating a custom one]({{< ref "../installation/automated" >}})
+- Connect to the machine via [SSH]({{< relref "../installation/manual" >}}) and start the installation process with a configuration file ( with `kairos-agent manual-install <config>`).
+- [Use a datasource iso, or a generating a custom one]({{< relref "../installation/automated" >}})
 
 The configuration file is a YAML file with `cloud-init` syntax and additional Kairos configuration details. In this example, we'll configure the node as a single-node Kubernetes cluster using K3s. We'll also set a default password for the Kairos user and define SSH keys.
 
@@ -209,17 +209,17 @@ k3s:
 
 Save this file as config.yaml and use it to start the installation process with kairos-agent manual-install config.yaml. This will configure the node as a single-node Kubernetes cluster and set the default password and SSH keys as specified in the configuration file.
 
-[Check out the full configuration reference]({{< ref "../reference/configuration" >}}).
+[Check out the full configuration reference]({{< relref "../reference/configuration" >}}).
 
 **Note**:
 
 - `users`: This block defines the user accounts on the node. In this example, it creates a user named `kairos` with the password `kairos` and adds two SSH keys to the user's authorized keys.
 - `k3s`: This block enables K3s on the node.
-- If you want to enable experimental P2P support, check out [P2P installation]({{< ref "../installation/p2p" >}})
+- If you want to enable experimental P2P support, check out [P2P installation]({{< relref "../installation/p2p" >}})
 
 {{% alert title="Note" %}}
 
-Several configurations can be added at this stage. [See the configuration reference]({{< ref "../reference/configuration" >}}) for further reading.
+Several configurations can be added at this stage. [See the configuration reference]({{< relref "../reference/configuration" >}}) for further reading.
 
 {{% /alert %}}
 
@@ -227,7 +227,7 @@ Several configurations can be added at this stage. [See the configuration refere
 
 {{% alert title="Note" %}}
 
-You can find instructions showing how to use the Kairos CLI below. In case you prefer to install via SSH and log in to the box, see the [Manual installation]({{< ref "../installation/manual" >}}) section or the [Interactive installation]({{< ref "../installation/interactive" >}}) section to perform the installation manually from the console.
+You can find instructions showing how to use the Kairos CLI below. In case you prefer to install via SSH and log in to the box, see the [Manual installation]({{< relref "../installation/manual" >}}) section or the [Interactive installation]({{< relref "../installation/interactive" >}}) section to perform the installation manually from the console.
 
 {{% /alert %}}
 
@@ -303,17 +303,17 @@ The K3s `kubeconfig` file is available at `/etc/rancher/k3s/k3s.yaml`. Please re
 
 There are other ways to install Kairos:
 
-- [Automated installation]({{< ref "../installation/automated" >}})
-- [Manual login and installation]({{< ref "../installation/manual" >}})
-- [Create decentralized clusters]({{< ref "../installation/p2p" >}})
-- [Take over installation]({{< ref "../installation/takeover" >}})
-- [Installation via network]({{< ref "../installation/netboot" >}})
-- [Raspberry Pi]({{< ref "../installation/raspberry" >}})
+- [Automated installation]({{< relref "../installation/automated" >}})
+- [Manual login and installation]({{< relref "../installation/manual" >}})
+- [Create decentralized clusters]({{< relref "../installation/p2p" >}})
+- [Take over installation]({{< relref "../installation/takeover" >}})
+- [Installation via network]({{< relref "../installation/netboot" >}})
+- [Raspberry Pi]({{< relref "../installation/raspberry" >}})
 - [CAPI Lifecycle Management (TODO)]()
 
 ## What's Next?
 
-- [Upgrade nodes with Kubernetes]({{< ref "../upgrade/kubernetes" >}})
-- [Upgrade nodes manually]({{< ref "../upgrade/manual" >}})
-- [Encrypt partitions]({{< ref "../advanced/partition_encryption" >}})
-- [Immutable architecture]({{< ref "../architecture/immutable" >}})
+- [Upgrade nodes with Kubernetes]({{< relref "../upgrade/kubernetes" >}})
+- [Upgrade nodes manually]({{< relref "../upgrade/manual" >}})
+- [Encrypt partitions]({{< relref "../advanced/partition_encryption" >}})
+- [Immutable architecture]({{< relref "../architecture/immutable" >}})

--- a/content/en/docs/Installation/automated.md
+++ b/content/en/docs/Installation/automated.md
@@ -49,7 +49,7 @@ kairos:
 ```
 
 The token `p2p.network_token` is a base64 encoded string which
-contains an [`edgevpn` token](https://github.com/mudler/edgevpn/blob/master/docs/content/en/docs/Concepts/Token/_index.md). For more information, [check out the architecture section](/docs/architecture/network).
+contains an [`edgevpn` token](https://github.com/mudler/edgevpn/blob/master/docs/content/en/docs/Concepts/Token/_index.md). For more information, [check out the architecture section]({{< ref "../architecture/network" >}}).
 
 Save this file as `cloud_init.yaml`, then create an ISO with the following steps:
 
@@ -80,7 +80,7 @@ If you're not sure where to host your configuration file, a common option is to 
 
 ## ISO remastering
 
-It is possible to create custom ISOs with an embedded cloud configuration. This allows the machine to automatically boot with a pre-specified configuration file, which will be installed on the system after provisioning is complete. See also [AuroraBoot](/docs/reference/auroraboot) for documentation.
+It is possible to create custom ISOs with an embedded cloud configuration. This allows the machine to automatically boot with a pre-specified configuration file, which will be installed on the system after provisioning is complete. See also [AuroraBoot]({{< ref "../reference/auroraboot" >}}) for documentation.
 
 ### Locally
 
@@ -97,7 +97,7 @@ If you don't pass one, we will make an attempt to read it as a web URL but depen
 {{< tabpane text=true  >}}
 {{% tab header="AuroraBoot" %}}
 
-We can use [AuroraBoot](/docs/reference/auroraboot) to handle the the ISO build process, for example:
+We can use [AuroraBoot]({{< ref "../reference/auroraboot" >}}) to handle the the ISO build process, for example:
 
 ```bash
 $ IMAGE=<scheme://host[:port]/path[:tag]>
@@ -144,9 +144,9 @@ $ docker run -v $PWD:/cOS -v /var/run/docker.sock:/var/run/docker.sock -i --rm q
 
 This will create a new ISO with your specified cloud configuration embedded in it. You can then use this ISO to boot your machine and automatically install Kairos with your desired settings.
 
-You can as well modify the image in this step and add additional packages before deployment. See [customizing the system image](/docs/advanced/customizing).
+You can as well modify the image in this step and add additional packages before deployment. See [customizing the system image]({{< ref "../advanced/customizing" >}}).
 
-Check out the [AuroraBoot documentation](/docs/reference/auroraboot) and the [examples](/docs/examples) for learn more on how to generate customized images for installation.
+Check out the [AuroraBoot documentation]({{< ref "../reference/auroraboot" >}}) and the [examples]({{< ref "../examples" >}}) for learn more on how to generate customized images for installation.
 
 ### Kubernetes
 
@@ -224,4 +224,4 @@ $ PORT=$(kubectl get svc osartifactbuilder-operator-osbuilder-nginx -o json | jq
 $ curl http://$IP:$PORT/hello-kairos.iso -o test.iso
 ```
 
-Check out the [dedicated section in the documentation](/docs/advanced/build) for further examples.
+Check out the [dedicated section in the documentation]({{< ref "../advanced/build" >}}) for further examples.

--- a/content/en/docs/Installation/automated.md
+++ b/content/en/docs/Installation/automated.md
@@ -49,7 +49,7 @@ kairos:
 ```
 
 The token `p2p.network_token` is a base64 encoded string which
-contains an [`edgevpn` token](https://github.com/mudler/edgevpn/blob/master/docs/content/en/docs/Concepts/Token/_index.md). For more information, [check out the architecture section]({{< ref "../architecture/network" >}}).
+contains an [`edgevpn` token](https://github.com/mudler/edgevpn/blob/master/docs/content/en/docs/Concepts/Token/_index.md). For more information, [check out the architecture section]({{< relref "../architecture/network" >}}).
 
 Save this file as `cloud_init.yaml`, then create an ISO with the following steps:
 
@@ -80,7 +80,7 @@ If you're not sure where to host your configuration file, a common option is to 
 
 ## ISO remastering
 
-It is possible to create custom ISOs with an embedded cloud configuration. This allows the machine to automatically boot with a pre-specified configuration file, which will be installed on the system after provisioning is complete. See also [AuroraBoot]({{< ref "../reference/auroraboot" >}}) for documentation.
+It is possible to create custom ISOs with an embedded cloud configuration. This allows the machine to automatically boot with a pre-specified configuration file, which will be installed on the system after provisioning is complete. See also [AuroraBoot]({{< relref "../reference/auroraboot" >}}) for documentation.
 
 ### Locally
 
@@ -97,7 +97,7 @@ If you don't pass one, we will make an attempt to read it as a web URL but depen
 {{< tabpane text=true  >}}
 {{% tab header="AuroraBoot" %}}
 
-We can use [AuroraBoot]({{< ref "../reference/auroraboot" >}}) to handle the the ISO build process, for example:
+We can use [AuroraBoot]({{< relref "../reference/auroraboot" >}}) to handle the the ISO build process, for example:
 
 ```bash
 $ IMAGE=<scheme://host[:port]/path[:tag]>
@@ -144,9 +144,9 @@ $ docker run -v $PWD:/cOS -v /var/run/docker.sock:/var/run/docker.sock -i --rm q
 
 This will create a new ISO with your specified cloud configuration embedded in it. You can then use this ISO to boot your machine and automatically install Kairos with your desired settings.
 
-You can as well modify the image in this step and add additional packages before deployment. See [customizing the system image]({{< ref "../advanced/customizing" >}}).
+You can as well modify the image in this step and add additional packages before deployment. See [customizing the system image]({{< relref "../advanced/customizing" >}}).
 
-Check out the [AuroraBoot documentation]({{< ref "../reference/auroraboot" >}}) and the [examples]({{< ref "../examples" >}}) for learn more on how to generate customized images for installation.
+Check out the [AuroraBoot documentation]({{< relref "../reference/auroraboot" >}}) and the [examples]({{< relref "../examples" >}}) for learn more on how to generate customized images for installation.
 
 ### Kubernetes
 
@@ -224,4 +224,4 @@ $ PORT=$(kubectl get svc osartifactbuilder-operator-osbuilder-nginx -o json | jq
 $ curl http://$IP:$PORT/hello-kairos.iso -o test.iso
 ```
 
-Check out the [dedicated section in the documentation]({{< ref "../advanced/build" >}}) for further examples.
+Check out the [dedicated section in the documentation]({{< relref "../advanced/build" >}}) for further examples.

--- a/content/en/docs/Installation/manual.md
+++ b/content/en/docs/Installation/manual.md
@@ -7,7 +7,7 @@ description: >
   Install Kairos manually
 ---
 
-To install manually, follow the [quickstart](/docs/getting-started). When the QR code is prompted at the screen, you will be able to log in via SSH to the box with the password `kairos` as `kairos` user.
+To install manually, follow the [quickstart]({{< ref "../Getting started" >}}). When the QR code is prompted at the screen, you will be able to log in via SSH to the box with the password `kairos` as `kairos` user.
 
 {{% alert title="Note" %}}
 
@@ -35,7 +35,7 @@ p2p:
 ```
 
 The token `p2p.network_token` is a base64 encoded string which
-contains an [`edgevpn` token](https://github.com/mudler/edgevpn/blob/master/docs/content/en/docs/Concepts/Token/_index.md). For more information, [check out the architecture section](/docs/architecture/network).
+contains an [`edgevpn` token](https://github.com/mudler/edgevpn/blob/master/docs/content/en/docs/Concepts/Token/_index.md). For more information, [check out the architecture section]({{< ref "../architecture/network" >}}).
 
 **Note**: 
 - The command is disruptive and will erase any content on the drive.

--- a/content/en/docs/Installation/manual.md
+++ b/content/en/docs/Installation/manual.md
@@ -7,7 +7,7 @@ description: >
   Install Kairos manually
 ---
 
-To install manually, follow the [quickstart]({{< ref "../Getting started" >}}). When the QR code is prompted at the screen, you will be able to log in via SSH to the box with the password `kairos` as `kairos` user.
+To install manually, follow the [quickstart]({{< relref "../Getting started" >}}). When the QR code is prompted at the screen, you will be able to log in via SSH to the box with the password `kairos` as `kairos` user.
 
 {{% alert title="Note" %}}
 
@@ -35,7 +35,7 @@ p2p:
 ```
 
 The token `p2p.network_token` is a base64 encoded string which
-contains an [`edgevpn` token](https://github.com/mudler/edgevpn/blob/master/docs/content/en/docs/Concepts/Token/_index.md). For more information, [check out the architecture section]({{< ref "../architecture/network" >}}).
+contains an [`edgevpn` token](https://github.com/mudler/edgevpn/blob/master/docs/content/en/docs/Concepts/Token/_index.md). For more information, [check out the architecture section]({{< relref "../architecture/network" >}}).
 
 **Note**: 
 - The command is disruptive and will erase any content on the drive.

--- a/content/en/docs/Installation/netboot.md
+++ b/content/en/docs/Installation/netboot.md
@@ -21,10 +21,10 @@ Booting using these files can happen in multiple ways:
 - Software based network booting. This works with a special ISO, built with
   [ipxe](https://ipxe.org/) project. Kairos releases include pre-built ISOs for
   netbooting (named like `*.ipxe.iso.ipxe`).
-- Use [AuroraBoot]({{< ref "../reference/auroraboot" >}})
+- Use [AuroraBoot]({{< relref "../reference/auroraboot" >}})
 
 Generic hardware based netbooting is out of scope for this document.
-Below we give instructions on how to use the Kairos release artifacts to netboot and how to use [AuroraBoot]({{< ref "../reference/auroraboot" >}}) to boot from network.
+Below we give instructions on how to use the Kairos release artifacts to netboot and how to use [AuroraBoot]({{< relref "../reference/auroraboot" >}}) to boot from network.
 
 ## Boot with pre-built ISOs
 
@@ -67,7 +67,7 @@ qemu-system-x86_64 \
 
 ## Use AuroraBoot
 
-[AuroraBoot]({{< ref "../reference/auroraboot" >}}) is a Kairos convinience tool that can be used to quickly deploy Kairos from Network with zero-touch configuration, for instance:
+[AuroraBoot]({{< relref "../reference/auroraboot" >}}) is a Kairos convinience tool that can be used to quickly deploy Kairos from Network with zero-touch configuration, for instance:
 
 ```bash
 docker run --rm -ti --net host quay.io/kairos/auroraboot \
@@ -76,7 +76,7 @@ docker run --rm -ti --net host quay.io/kairos/auroraboot \
                     # --cloud-config ....
 ```
 
-Will netboot the `quay.io/kairos/kairos-opensuse-leap:{{<providerVersion>}}-{{<k3sVersion>}}` image. You can find more details in the [AuroraBoot documentation section]({{< ref "../reference/auroraboot" >}}).
+Will netboot the `quay.io/kairos/kairos-opensuse-leap:{{<providerVersion>}}-{{<k3sVersion>}}` image. You can find more details in the [AuroraBoot documentation section]({{< relref "../reference/auroraboot" >}}).
 
 ## Notes on booting from network
 

--- a/content/en/docs/Installation/netboot.md
+++ b/content/en/docs/Installation/netboot.md
@@ -21,10 +21,10 @@ Booting using these files can happen in multiple ways:
 - Software based network booting. This works with a special ISO, built with
   [ipxe](https://ipxe.org/) project. Kairos releases include pre-built ISOs for
   netbooting (named like `*.ipxe.iso.ipxe`).
-- Use [AuroraBoot](/docs/reference/auroraboot)
+- Use [AuroraBoot]({{< ref "../reference/auroraboot" >}})
 
 Generic hardware based netbooting is out of scope for this document.
-Below we give instructions on how to use the Kairos release artifacts to netboot and how to use [AuroraBoot](/docs/reference/auroraboot) to boot from network.
+Below we give instructions on how to use the Kairos release artifacts to netboot and how to use [AuroraBoot]({{< ref "../reference/auroraboot" >}}) to boot from network.
 
 ## Boot with pre-built ISOs
 
@@ -67,7 +67,7 @@ qemu-system-x86_64 \
 
 ## Use AuroraBoot
 
-[AuroraBoot](/docs/reference/auroraboot) is a Kairos convinience tool that can be used to quickly deploy Kairos from Network with zero-touch configuration, for instance:
+[AuroraBoot]({{< ref "../reference/auroraboot" >}}) is a Kairos convinience tool that can be used to quickly deploy Kairos from Network with zero-touch configuration, for instance:
 
 ```bash
 docker run --rm -ti --net host quay.io/kairos/auroraboot \
@@ -76,7 +76,7 @@ docker run --rm -ti --net host quay.io/kairos/auroraboot \
                     # --cloud-config ....
 ```
 
-Will netboot the `quay.io/kairos/kairos-opensuse-leap:{{<providerVersion>}}-{{<k3sVersion>}}` image. You can find more details in the [AuroraBoot documentation section](/docs/reference/auroraboot).
+Will netboot the `quay.io/kairos/kairos-opensuse-leap:{{<providerVersion>}}-{{<k3sVersion>}}` image. You can find more details in the [AuroraBoot documentation section]({{< ref "../reference/auroraboot" >}}).
 
 ## Notes on booting from network
 

--- a/content/en/docs/Installation/p2p.md
+++ b/content/en/docs/Installation/p2p.md
@@ -18,16 +18,16 @@ Deploying Kubernetes at the Edge can be a complex and time-consuming process, es
 
 With this feature, users don't need to specify any network settings. They can just set the desired number of master nodes (in the case of an HA cluster) and the necessary configuration details, and Kairos will take care of the rest. The peer-to-peer technology allows the nodes in the cluster to communicate and coordinate with each other, ensuring that the clusters are set up correctly and efficiently with K3s.
 
-This makes it easier to deploy and manage Kubernetes clusters at the Edge, saving user's time and effort, allowing them to focus on running and scaling their applications. For more information about how does it work behind the scenes, [check out the architecture section]({{< ref "../architecture/network" >}}).
+This makes it easier to deploy and manage Kubernetes clusters at the Edge, saving user's time and effort, allowing them to focus on running and scaling their applications. For more information about how does it work behind the scenes, [check out the architecture section]({{< relref "../architecture/network" >}}).
 
-You can find full examples in our [examples section]({{< ref "../examples" >}}):
-- [Full end to end example to bootstrap a self-coordinated cluster with Kairos and AuroraBoot]({{< ref "../examples/p2p_e2e" >}})
-- [Self-coordinated K3s HA cluster with KubeVIP]({{< ref "../examples/multi-node-p2p-ha-kubevip" >}})
-- [Multi-node, single master setup]({{< ref "../examples/multi-node-p2p" >}})
-- [Multi-node, HA setup]({{< ref "../examples/multi-node-p2p-ha" >}})
-- [Single-node setup]({{< ref "../examples/single-node-p2p" >}})
+You can find full examples in our [examples section]({{< relref "../examples" >}}):
+- [Full end to end example to bootstrap a self-coordinated cluster with Kairos and AuroraBoot]({{< relref "../examples/p2p_e2e" >}})
+- [Self-coordinated K3s HA cluster with KubeVIP]({{< relref "../examples/multi-node-p2p-ha-kubevip" >}})
+- [Multi-node, single master setup]({{< relref "../examples/multi-node-p2p" >}})
+- [Multi-node, HA setup]({{< relref "../examples/multi-node-p2p-ha" >}})
+- [Single-node setup]({{< relref "../examples/single-node-p2p" >}})
 
-This feature is currently experimental and can be optionally enabled by adding the following configuration to the node deployment file. If you are not familiar with the installation process, it is suggested to follow the [quickstart]({{< ref "../Getting started" >}}):
+This feature is currently experimental and can be optionally enabled by adding the following configuration to the node deployment file. If you are not familiar with the installation process, it is suggested to follow the [quickstart]({{< relref "../Getting started" >}}):
 
 ```yaml
 p2p:
@@ -80,7 +80,7 @@ The `k3s` block can still be used to override other `k3s` settings, e.g. `args`.
 
 {{% /alert %}}
 
-The network token is a shared secret available to all the nodes of the cluster. It allows the node to co-ordinate and automatically assign roles. To generate a network token, see [documentation]({{< ref "../installation/p2p#network_token" >}}).
+The network token is a shared secret available to all the nodes of the cluster. It allows the node to co-ordinate and automatically assign roles. To generate a network token, see [documentation]({{< relref "../installation/p2p#network_token" >}}).
 
 Simply applying the same configuration file to all the nodes should eventually bring one master and all the other nodes as workers. Adding nodes can be done also in a later step, which will automatically setup the node without any further configuration.
 

--- a/content/en/docs/Installation/p2p.md
+++ b/content/en/docs/Installation/p2p.md
@@ -18,16 +18,16 @@ Deploying Kubernetes at the Edge can be a complex and time-consuming process, es
 
 With this feature, users don't need to specify any network settings. They can just set the desired number of master nodes (in the case of an HA cluster) and the necessary configuration details, and Kairos will take care of the rest. The peer-to-peer technology allows the nodes in the cluster to communicate and coordinate with each other, ensuring that the clusters are set up correctly and efficiently with K3s.
 
-This makes it easier to deploy and manage Kubernetes clusters at the Edge, saving user's time and effort, allowing them to focus on running and scaling their applications. For more information about how does it work behind the scenes, [check out the architecture section](/docs/architecture/network).
+This makes it easier to deploy and manage Kubernetes clusters at the Edge, saving user's time and effort, allowing them to focus on running and scaling their applications. For more information about how does it work behind the scenes, [check out the architecture section]({{< ref "../architecture/network" >}}).
 
-You can find full examples in our [examples section](/docs/examples):
-- [Full end to end example to bootstrap a self-coordinated cluster with Kairos and AuroraBoot](/docs/examples/p2p_e2e/)
-- [Self-coordinated K3s HA cluster with KubeVIP](/docs/examples/multi-node-p2p-ha-kubevip/)
-- [Multi-node, single master setup](/docs/examples/multi-node-p2p/)
-- [Multi-node, HA setup](/docs/examples/multi-node-p2p-ha/)
-- [Single-node setup](/docs/examples/single-node-p2p/)
+You can find full examples in our [examples section]({{< ref "../examples" >}}):
+- [Full end to end example to bootstrap a self-coordinated cluster with Kairos and AuroraBoot]({{< ref "../examples/p2p_e2e" >}})
+- [Self-coordinated K3s HA cluster with KubeVIP]({{< ref "../examples/multi-node-p2p-ha-kubevip" >}})
+- [Multi-node, single master setup]({{< ref "../examples/multi-node-p2p" >}})
+- [Multi-node, HA setup]({{< ref "../examples/multi-node-p2p-ha" >}})
+- [Single-node setup]({{< ref "../examples/single-node-p2p" >}})
 
-This feature is currently experimental and can be optionally enabled by adding the following configuration to the node deployment file. If you are not familiar with the installation process, it is suggested to follow the [quickstart](/docs/getting-started):
+This feature is currently experimental and can be optionally enabled by adding the following configuration to the node deployment file. If you are not familiar with the installation process, it is suggested to follow the [quickstart]({{< ref "../Getting started" >}}):
 
 ```yaml
 p2p:
@@ -80,7 +80,7 @@ The `k3s` block can still be used to override other `k3s` settings, e.g. `args`.
 
 {{% /alert %}}
 
-The network token is a shared secret available to all the nodes of the cluster. It allows the node to co-ordinate and automatically assign roles. To generate a network token, see [documentation](/docs/installation/p2p/#network_token).
+The network token is a shared secret available to all the nodes of the cluster. It allows the node to co-ordinate and automatically assign roles. To generate a network token, see [documentation]({{< ref "../installation/p2p#network_token" >}}).
 
 Simply applying the same configuration file to all the nodes should eventually bring one master and all the other nodes as workers. Adding nodes can be done also in a later step, which will automatically setup the node without any further configuration.
 

--- a/content/en/docs/Installation/qrcode.md
+++ b/content/en/docs/Installation/qrcode.md
@@ -43,9 +43,9 @@ mdns: HPtZilIJxPXbQTTHOwdxbXfxKroVbfdH
 max_message_size: 20971520
 ```
 
-For more information about EdgeVPN, [check out the architecture section]({{< ref "../architecture/network" >}}).
+For more information about EdgeVPN, [check out the architecture section]({{< relref "../architecture/network" >}}).
 
-To trigger the installation process via QR code, you need to use the Kairos CLI and provide a Cloud Config, as described in the [Getting started guide]({{< ref "../Getting started" >}}). You can also see some Cloud Config examples in our [Examples section]({{< ref "../examples" >}}). The CLI is currently available only for Linux and Windows. It can be downloaded from the release artifact:
+To trigger the installation process via QR code, you need to use the Kairos CLI and provide a Cloud Config, as described in the [Getting started guide]({{< relref "../Getting started" >}}). You can also see some Cloud Config examples in our [Examples section]({{< relref "../examples" >}}). The CLI is currently available only for Linux and Windows. It can be downloaded from the release artifact:
 
 ```bash
 VERSION=$(wget -q -O- https://api.github.com/repos/kairos-io/provider-kairos/releases/latest | jq -r '.tag_name')

--- a/content/en/docs/Installation/qrcode.md
+++ b/content/en/docs/Installation/qrcode.md
@@ -43,9 +43,9 @@ mdns: HPtZilIJxPXbQTTHOwdxbXfxKroVbfdH
 max_message_size: 20971520
 ```
 
-For more information about EdgeVPN, [check out the architecture section](/docs/architecture/network).
+For more information about EdgeVPN, [check out the architecture section]({{< ref "../architecture/network" >}}).
 
-To trigger the installation process via QR code, you need to use the Kairos CLI and provide a Cloud Config, as described in the [Getting started guide](/docs/getting-started). You can also see some Cloud Config examples in our [Examples section](/docs/examples). The CLI is currently available only for Linux and Windows. It can be downloaded from the release artifact:
+To trigger the installation process via QR code, you need to use the Kairos CLI and provide a Cloud Config, as described in the [Getting started guide]({{< ref "../Getting started" >}}). You can also see some Cloud Config examples in our [Examples section]({{< ref "../examples" >}}). The CLI is currently available only for Linux and Windows. It can be downloaded from the release artifact:
 
 ```bash
 VERSION=$(wget -q -O- https://api.github.com/repos/kairos-io/provider-kairos/releases/latest | jq -r '.tag_name')

--- a/content/en/docs/Installation/raspberry.md
+++ b/content/en/docs/Installation/raspberry.md
@@ -9,7 +9,7 @@ description: >
 
 Kairos supports Raspberry Pi model 3 and 4 with 64bit architecture.
 
-If you are not familiar with the process, it is suggested to follow the [quickstart]({{< ref "../Getting started" >}}) first to see how Kairos works.
+If you are not familiar with the process, it is suggested to follow the [quickstart]({{< relref "../Getting started" >}}) first to see how Kairos works.
 
 ## Prerequisites
 
@@ -19,7 +19,7 @@ If you are not familiar with the process, it is suggested to follow the [quickst
 
 ## Download
 
-Extract the `img` file from a container image as described [in this page]({{< ref "../reference/image_matrix" >}})
+Extract the `img` file from a container image as described [in this page]({{< relref "../reference/image_matrix" >}})
 
 ## Flash the image
 
@@ -49,7 +49,7 @@ $ sudo cp cloud-config.yaml /tmp/persistent/cloud-config
 $ sudo umount /tmp/persistent
 ```
 
-You can push additional `cloud config` files. For a full reference check out the [docs]({{< ref "../reference/configuration" >}}) and also [configuration after-installation]({{< ref "../advanced/after-install" >}})
+You can push additional `cloud config` files. For a full reference check out the [docs]({{< relref "../reference/configuration" >}}) and also [configuration after-installation]({{< relref "../advanced/after-install" >}})
 
 ## Customizing the disk image
 
@@ -61,7 +61,7 @@ If you're using osbuilder between versions 0.6.0 and 0.6.5, you need to pass the
 {{% /alert %}}
 
 {{% alert title="Notes" %}}
-Validating the config is not required in the following process, but it can save you some time. Use [kairosctl]({{< ref "../reference/kairosctl" >}}) to perform the schema validations.
+Validating the config is not required in the following process, but it can save you some time. Use [kairosctl]({{< relref "../reference/kairosctl" >}}) to perform the schema validations.
 {{% /alert %}}
 
 ```

--- a/content/en/docs/Installation/raspberry.md
+++ b/content/en/docs/Installation/raspberry.md
@@ -9,7 +9,7 @@ description: >
 
 Kairos supports Raspberry Pi model 3 and 4 with 64bit architecture.
 
-If you are not familiar with the process, it is suggested to follow the [quickstart](/docs/getting-started) first to see how Kairos works.
+If you are not familiar with the process, it is suggested to follow the [quickstart]({{< ref "../Getting started" >}}) first to see how Kairos works.
 
 ## Prerequisites
 
@@ -19,7 +19,7 @@ If you are not familiar with the process, it is suggested to follow the [quickst
 
 ## Download
 
-Extract the `img` file from a container image as described [in this page](/docs/reference/image_matrix)
+Extract the `img` file from a container image as described [in this page]({{< ref "../reference/image_matrix" >}})
 
 ## Flash the image
 
@@ -49,7 +49,7 @@ $ sudo cp cloud-config.yaml /tmp/persistent/cloud-config
 $ sudo umount /tmp/persistent
 ```
 
-You can push additional `cloud config` files. For a full reference check out the [docs](/docs/reference/configuration) and also [configuration after-installation](/docs/advanced/after-install)
+You can push additional `cloud config` files. For a full reference check out the [docs]({{< ref "../reference/configuration" >}}) and also [configuration after-installation]({{< ref "../advanced/after-install" >}})
 
 ## Customizing the disk image
 
@@ -61,7 +61,7 @@ If you're using osbuilder between versions 0.6.0 and 0.6.5, you need to pass the
 {{% /alert %}}
 
 {{% alert title="Notes" %}}
-Validating the config is not required in the following process, but it can save you some time. Use [kairosctl](/docs/reference/kairosctl/) to perform the schema validations.
+Validating the config is not required in the following process, but it can save you some time. Use [kairosctl]({{< ref "../reference/kairosctl" >}}) to perform the schema validations.
 {{% /alert %}}
 
 ```

--- a/content/en/docs/Installation/webui.md
+++ b/content/en/docs/Installation/webui.md
@@ -17,4 +17,4 @@ By default when running the LiveCD, or during installation, Kairos will start a 
 
 ![WebUI](https://user-images.githubusercontent.com/2420543/214573939-31f887b8-890c-4cce-a02a-0100198ea7d9.png)
 
-The WebUI has an input form that accepts the `YAML` config file, features a syntax highlighter and a `YAML` syntax checker. You can find a [full example in our documentation]({{< ref "../reference/configuration" >}}) or navigate to our [examples section]({{< ref "../examples" >}}).
+The WebUI has an input form that accepts the `YAML` config file, features a syntax highlighter and a `YAML` syntax checker. You can find a [full example in our documentation]({{< relref "../reference/configuration" >}}) or navigate to our [examples section]({{< relref "../examples" >}}).

--- a/content/en/docs/Installation/webui.md
+++ b/content/en/docs/Installation/webui.md
@@ -17,4 +17,4 @@ By default when running the LiveCD, or during installation, Kairos will start a 
 
 ![WebUI](https://user-images.githubusercontent.com/2420543/214573939-31f887b8-890c-4cce-a02a-0100198ea7d9.png)
 
-The WebUI has an input form that accepts the `YAML` config file, features a syntax highlighter and a `YAML` syntax checker. You can find a [full example in our documentation](/docs/reference/configuration) or navigate to our [examples section](/docs/examples).
+The WebUI has an input form that accepts the `YAML` config file, features a syntax highlighter and a `YAML` syntax checker. You can find a [full example in our documentation]({{< ref "../reference/configuration" >}}) or navigate to our [examples section]({{< ref "../examples" >}}).

--- a/content/en/docs/Reference/auroraboot.md
+++ b/content/en/docs/Reference/auroraboot.md
@@ -90,7 +90,7 @@ By default AuroraBoot will automatically attempt to bootstrap other machines, wh
 
 There are only 3 steps involved in the process:
 
-1. Select the release of Kairos that you want to deploy and optionally a cloud config (see also our [examples](/docs/examples))
+1. Select the release of Kairos that you want to deploy and optionally a cloud config (see also our [examples]({{< ref "../examples" >}}))
 1. Run AuroraBoot in your workstation with the appropriate CLI args
 1. Boot up other nodes, already configured to boot from network
 
@@ -99,9 +99,9 @@ There are only 3 steps involved in the process:
 AuroraBoot can bootstrap container images or released assets from our GitHub release process. 
 
 To use GitHub releases set a release version with `--set release_version` (the GitHub release), an artifact version with `--set artifact_version` (the artifact version) a flavor with `--set flavor` and a repository with `--set repository`.
-Kairos has releases with and without k3s. The [release page at kairos](https://github.com/kairos-io/kairos/releases) are ["core" images that can be used as installer](/docs/examples/core/) while the [provider-kairos](https://github.com/kairos-io/provider-kairos/releases) images contains also `k3s`.
+Kairos has releases with and without k3s. The [release page at kairos](https://github.com/kairos-io/kairos/releases) are ["core" images that can be used as installer]({{< ref "../examples/core" >}}) while the [provider-kairos](https://github.com/kairos-io/provider-kairos/releases) images contains also `k3s`.
 
-To use a container image, you can use [the Kairos released images](/docs/reference/image_matrix/) or [customized](/docs/advanced/customizing) by specifying `--set container_image` instead with the container image of choice.
+To use a container image, you can use [the Kairos released images]({{< ref "../reference/image_matrix" >}}) or [customized]({{< ref "../advanced/customizing" >}}) by specifying `--set container_image` instead with the container image of choice.
 
 #### 2. Run AuroraBoot
 
@@ -114,7 +114,7 @@ In the example below we selected `v1.5.1-k3sv1.21.14-k3s1`, `opensuse-leap` flav
 
 By indicating a `container_image`, AuroraBoot will pull the image locally and start to serve it for network booting.
 
-You can use [the Kairos released images](/docs/reference/image_matrix/) or [your own](/docs/advanced/customizing).
+You can use [the Kairos released images]({{< ref "../reference/image_matrix" >}}) or [your own]({{< ref "../advanced/customizing" >}}).
 
 ```bash
 docker run --rm -ti --net host quay.io/kairos/auroraboot \
@@ -185,7 +185,7 @@ To disable netboot and provide only offline artifacts, run `auroraboot` with `--
 
 #### 1. Node configuration
 
-Create a cloud config file, see [our documentation](/docs/examples) for ready-to use examples, but a minimal configuration that automatically installs, and allows us to login afterward can be the following:
+Create a cloud config file, see [our documentation]({{< ref "../examples" >}}) for ready-to use examples, but a minimal configuration that automatically installs, and allows us to login afterward can be the following:
 
 ```yaml
 #cloud-config
@@ -365,21 +365,21 @@ listen_addr: ":8080"
 cloud_config: |
 ```
 
-| Option | Description |
-| ------ | ----------- |
-| `artifact_version` | Corresponding artifact versions from the Kairos release page (e.g. Kubernetes version included). |
-| `release_version` | Version of the release in GitHub. |
-| `flavor` | The Kairos flavor to use. See [the Kairos support matrix](/docs/reference/image_matrix/) for a list. |
-| `repository` | Github repository to use. This can either be `kairos-io/kairos` or `kairos-io/provider-kairos` for images with `k3s`. |
-| `container_image` | Container image. If prefixed with `docker://` it will try to pull from the local docker daemon. If a `container_image` is specified, `artifact_version`, `flavor` and `release_version` are ignored. |
-| `disable_netboot` | Disable netboot. |
-| `disable_http_server` | Disable http server for serving offline generated ISOs. |
-| `netboot_http_port` | Specify a netboot HTTP port (defaults to `8090`). |
-| `state_dir` | Specify a directory that will be used by auroraboot to download artifacts and reuse the same to cache artifacts. |
-| `listen_addr` | Default http binding port for offline ISO generation. |
-| `cloud_config` | Cloud config path to use for the machines. A URL can be specified, use `-` to pass-by the cloud-config from _STDIN_ |
-| `iso.data` | Defines a path to be embedded into the resulting iso. When booting, the files will be accessible at `/run/initramfs/live` |
-| `netboot.cmdlin` | Override the automatically generated cmdline with a custom one to use during netboot. `config_url` and `rootfs`  are automatically constructed. A reasonable value can be `netboot.cmdline=rd.neednet=1 ip=dhcp rd.cos.disable netboot nodepair.enable console=tty0` |
+| Option                | Description                                                                                                                                                                                                                                                          |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `artifact_version`    | Corresponding artifact versions from the Kairos release page (e.g. Kubernetes version included).                                                                                                                                                                     |
+| `release_version`     | Version of the release in GitHub.                                                                                                                                                                                                                                    |
+| `flavor`              | The Kairos flavor to use. See [the Kairos support matrix]({{< ref "../reference/image_matrix" >}}) for a list.                                                                                                                                                       |
+| `repository`          | Github repository to use. This can either be `kairos-io/kairos` or `kairos-io/provider-kairos` for images with `k3s`.                                                                                                                                                |
+| `container_image`     | Container image. If prefixed with `docker://` it will try to pull from the local docker daemon. If a `container_image` is specified, `artifact_version`, `flavor` and `release_version` are ignored.                                                                 |
+| `disable_netboot`     | Disable netboot.                                                                                                                                                                                                                                                     |
+| `disable_http_server` | Disable http server for serving offline generated ISOs.                                                                                                                                                                                                              |
+| `netboot_http_port`   | Specify a netboot HTTP port (defaults to `8090`).                                                                                                                                                                                                                    |
+| `state_dir`           | Specify a directory that will be used by auroraboot to download artifacts and reuse the same to cache artifacts.                                                                                                                                                     |
+| `listen_addr`         | Default http binding port for offline ISO generation.                                                                                                                                                                                                                |
+| `cloud_config`        | Cloud config path to use for the machines. A URL can be specified, use `-` to pass-by the cloud-config from _STDIN_                                                                                                                                                  |
+| `iso.data`            | Defines a path to be embedded into the resulting iso. When booting, the files will be accessible at `/run/initramfs/live`                                                                                                                                            |
+| `netboot.cmdlin`      | Override the automatically generated cmdline with a custom one to use during netboot. `config_url` and `rootfs`  are automatically constructed. A reasonable value can be `netboot.cmdline=rd.neednet=1 ip=dhcp rd.cos.disable netboot nodepair.enable console=tty0` |
 
 To use the configuration file with AuroraBoot, run AuroraBoot specifying the file or URL of the config as first argument:
 
@@ -553,7 +553,7 @@ docker run -v "$PWD"/config.yaml:/config.yaml \
 
 ### Prepare ISO for Airgap installations
 
-See the [Airgap example](/docs/examples/airgap) in the [examples section](/docs/examples).
+See the [Airgap example]({{< ref "../examples/airgap" >}}) in the [examples section]({{< ref "../examples" >}}).
 
 ### Netboot with core images from Github releases
 

--- a/content/en/docs/Reference/auroraboot.md
+++ b/content/en/docs/Reference/auroraboot.md
@@ -90,7 +90,7 @@ By default AuroraBoot will automatically attempt to bootstrap other machines, wh
 
 There are only 3 steps involved in the process:
 
-1. Select the release of Kairos that you want to deploy and optionally a cloud config (see also our [examples]({{< ref "../examples" >}}))
+1. Select the release of Kairos that you want to deploy and optionally a cloud config (see also our [examples]({{< relref "../examples" >}}))
 1. Run AuroraBoot in your workstation with the appropriate CLI args
 1. Boot up other nodes, already configured to boot from network
 
@@ -99,9 +99,9 @@ There are only 3 steps involved in the process:
 AuroraBoot can bootstrap container images or released assets from our GitHub release process. 
 
 To use GitHub releases set a release version with `--set release_version` (the GitHub release), an artifact version with `--set artifact_version` (the artifact version) a flavor with `--set flavor` and a repository with `--set repository`.
-Kairos has releases with and without k3s. The [release page at kairos](https://github.com/kairos-io/kairos/releases) are ["core" images that can be used as installer]({{< ref "../examples/core" >}}) while the [provider-kairos](https://github.com/kairos-io/provider-kairos/releases) images contains also `k3s`.
+Kairos has releases with and without k3s. The [release page at kairos](https://github.com/kairos-io/kairos/releases) are ["core" images that can be used as installer]({{< relref "../examples/core" >}}) while the [provider-kairos](https://github.com/kairos-io/provider-kairos/releases) images contains also `k3s`.
 
-To use a container image, you can use [the Kairos released images]({{< ref "../reference/image_matrix" >}}) or [customized]({{< ref "../advanced/customizing" >}}) by specifying `--set container_image` instead with the container image of choice.
+To use a container image, you can use [the Kairos released images]({{< relref "../reference/image_matrix" >}}) or [customized]({{< relref "../advanced/customizing" >}}) by specifying `--set container_image` instead with the container image of choice.
 
 #### 2. Run AuroraBoot
 
@@ -114,7 +114,7 @@ In the example below we selected `v1.5.1-k3sv1.21.14-k3s1`, `opensuse-leap` flav
 
 By indicating a `container_image`, AuroraBoot will pull the image locally and start to serve it for network booting.
 
-You can use [the Kairos released images]({{< ref "../reference/image_matrix" >}}) or [your own]({{< ref "../advanced/customizing" >}}).
+You can use [the Kairos released images]({{< relref "../reference/image_matrix" >}}) or [your own]({{< relref "../advanced/customizing" >}}).
 
 ```bash
 docker run --rm -ti --net host quay.io/kairos/auroraboot \
@@ -185,7 +185,7 @@ To disable netboot and provide only offline artifacts, run `auroraboot` with `--
 
 #### 1. Node configuration
 
-Create a cloud config file, see [our documentation]({{< ref "../examples" >}}) for ready-to use examples, but a minimal configuration that automatically installs, and allows us to login afterward can be the following:
+Create a cloud config file, see [our documentation]({{< relref "../examples" >}}) for ready-to use examples, but a minimal configuration that automatically installs, and allows us to login afterward can be the following:
 
 ```yaml
 #cloud-config
@@ -369,7 +369,7 @@ cloud_config: |
 |-----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `artifact_version`    | Corresponding artifact versions from the Kairos release page (e.g. Kubernetes version included).                                                                                                                                                                     |
 | `release_version`     | Version of the release in GitHub.                                                                                                                                                                                                                                    |
-| `flavor`              | The Kairos flavor to use. See [the Kairos support matrix]({{< ref "../reference/image_matrix" >}}) for a list.                                                                                                                                                       |
+| `flavor`              | The Kairos flavor to use. See [the Kairos support matrix]({{< relref "../reference/image_matrix" >}}) for a list.                                                                                                                                                       |
 | `repository`          | Github repository to use. This can either be `kairos-io/kairos` or `kairos-io/provider-kairos` for images with `k3s`.                                                                                                                                                |
 | `container_image`     | Container image. If prefixed with `docker://` it will try to pull from the local docker daemon. If a `container_image` is specified, `artifact_version`, `flavor` and `release_version` are ignored.                                                                 |
 | `disable_netboot`     | Disable netboot.                                                                                                                                                                                                                                                     |
@@ -553,7 +553,7 @@ docker run -v "$PWD"/config.yaml:/config.yaml \
 
 ### Prepare ISO for Airgap installations
 
-See the [Airgap example]({{< ref "../examples/airgap" >}}) in the [examples section]({{< ref "../examples" >}}).
+See the [Airgap example]({{< relref "../examples/airgap" >}}) in the [examples section]({{< relref "../examples" >}}).
 
 ### Netboot with core images from Github releases
 

--- a/content/en/docs/Reference/build-from-scratch.md
+++ b/content/en/docs/Reference/build-from-scratch.md
@@ -23,7 +23,7 @@ The Kairos contract is straightforward: the OS container image must include ever
 The contract has several advantages:
 
 - Delegation of package maintenance, CVE, and security fixes to the OS layer
-- Easy issuance of upgrades to container images by chaining Dockerfiles or manually committing changes to the image. See also [Customizing](/docs/advanced/customizing).
+- Easy issuance of upgrades to container images by chaining Dockerfiles or manually committing changes to the image. See also [Customizing]({{< ref "../advanced/customizing" >}}).
 - Clear separation of concerns: the OS provides the booting bits and packages necessary for the OS to function, while Kairos provides the operational framework for handling the node's lifecycle and immutability interface.
 - Support for long-term maintenance: each framework image allows conversion of any OS to the given Kairos framework version, potentially enabling maintenance for as long as the base OS support model allows.
 
@@ -152,12 +152,12 @@ docker build -t test-byoi .
 
 ## Build bootable assets
 
-Once the container image is built, we can proceed directly to creating an ISO or netboot it using [AuroraBoot](/docs/reference/auroraboot). We can use AuroraBoot to handle the ISO build process and even attach a default cloud config if desired. Here's an example for both scenarios:
+Once the container image is built, we can proceed directly to creating an ISO or netboot it using [AuroraBoot]({{< ref "../reference/auroraboot" >}}). We can use AuroraBoot to handle the ISO build process and even attach a default cloud config if desired. Here's an example for both scenarios:
 
 {{< tabpane text=true  >}}
 {{% tab header="ISO" %}}
 
-We can use [AuroraBoot](/docs/reference/auroraboot) to handle the the ISO build process and optionally attach it a default cloud config, for example:
+We can use [AuroraBoot]({{< ref "../reference/auroraboot" >}}) to handle the ISO build process and optionally attach it a default cloud config, for example:
 
 ```bash
 docker run -v "$PWD"/build:/tmp/auroraboot \
@@ -187,7 +187,7 @@ qemu-system-x86_64 -m 2048 -drive if=virtio,media=disk,file=build/iso/kairos.iso
 
 {{% tab header="Netboot" %}}
 
-To netboot, we can also use [AuroraBoot](/docs/reference/auroraboot) to handle the process, or refer to [Netboot](/docs/installation/netboot). Here's an example:
+To netboot, we can also use [AuroraBoot]({{< ref "../reference/auroraboot" >}}) to handle the process, or refer to [Netboot]({{< ref "../installation/netboot" >}}). Here's an example:
 
 ```bash
 docker run -v --net host \

--- a/content/en/docs/Reference/build-from-scratch.md
+++ b/content/en/docs/Reference/build-from-scratch.md
@@ -23,7 +23,7 @@ The Kairos contract is straightforward: the OS container image must include ever
 The contract has several advantages:
 
 - Delegation of package maintenance, CVE, and security fixes to the OS layer
-- Easy issuance of upgrades to container images by chaining Dockerfiles or manually committing changes to the image. See also [Customizing]({{< ref "../advanced/customizing" >}}).
+- Easy issuance of upgrades to container images by chaining Dockerfiles or manually committing changes to the image. See also [Customizing]({{< relref "../advanced/customizing" >}}).
 - Clear separation of concerns: the OS provides the booting bits and packages necessary for the OS to function, while Kairos provides the operational framework for handling the node's lifecycle and immutability interface.
 - Support for long-term maintenance: each framework image allows conversion of any OS to the given Kairos framework version, potentially enabling maintenance for as long as the base OS support model allows.
 
@@ -152,12 +152,12 @@ docker build -t test-byoi .
 
 ## Build bootable assets
 
-Once the container image is built, we can proceed directly to creating an ISO or netboot it using [AuroraBoot]({{< ref "../reference/auroraboot" >}}). We can use AuroraBoot to handle the ISO build process and even attach a default cloud config if desired. Here's an example for both scenarios:
+Once the container image is built, we can proceed directly to creating an ISO or netboot it using [AuroraBoot]({{< relref "../reference/auroraboot" >}}). We can use AuroraBoot to handle the ISO build process and even attach a default cloud config if desired. Here's an example for both scenarios:
 
 {{< tabpane text=true  >}}
 {{% tab header="ISO" %}}
 
-We can use [AuroraBoot]({{< ref "../reference/auroraboot" >}}) to handle the ISO build process and optionally attach it a default cloud config, for example:
+We can use [AuroraBoot]({{< relref "../reference/auroraboot" >}}) to handle the ISO build process and optionally attach it a default cloud config, for example:
 
 ```bash
 docker run -v "$PWD"/build:/tmp/auroraboot \
@@ -187,7 +187,7 @@ qemu-system-x86_64 -m 2048 -drive if=virtio,media=disk,file=build/iso/kairos.iso
 
 {{% tab header="Netboot" %}}
 
-To netboot, we can also use [AuroraBoot]({{< ref "../reference/auroraboot" >}}) to handle the process, or refer to [Netboot]({{< ref "../installation/netboot" >}}). Here's an example:
+To netboot, we can also use [AuroraBoot]({{< relref "../reference/auroraboot" >}}) to handle the process, or refer to [Netboot]({{< relref "../installation/netboot" >}}). Here's an example:
 
 ```bash
 docker run -v --net host \

--- a/content/en/docs/Reference/configuration.md
+++ b/content/en/docs/Reference/configuration.md
@@ -192,7 +192,7 @@ Kairos supports a portion of the standard [cloud-init](https://cloud-init.io/) s
 
 Examples using the extended notation for running K3s as agent or server can be found in the [examples](https://github.com/kairos-io/kairos/tree/master/examples)  directory of the Kairos repository.
 
-Here's an example that shows how to set up DNS at the [boot stage](/docs/architecture/cloud-init) using the extended syntax:
+Here's an example that shows how to set up DNS at the [boot stage]({{< ref "../architecture/cloud-init" >}}) using the extended syntax:
 
 ```yaml
 #cloud-config
@@ -363,7 +363,7 @@ k3s-agent:
 {{% /tab %}}
 {{< /tabpane >}}
 
-For more examples of how to configure K3s manually, see the [examples](/docs/examples) section or [HA](/docs/advanced/ha).
+For more examples of how to configure K3s manually, see the [examples]({{< ref "../examples" >}}) section or [HA]({{< ref "../examples/ha" >}}).
 
 ### Grub options
 
@@ -382,7 +382,7 @@ install:
 The table below lists all the available options for the `install.grub_options` field:
 
 | Variable               | Description                                             |
-| ---------------------- | ------------------------------------------------------- |
+|------------------------|---------------------------------------------------------|
 | next_entry             | Set the next reboot entry                               |
 | saved_entry            | Set the default boot entry                              |
 | default_menu_entry     | Set the name entries on the GRUB menu                   |
@@ -486,7 +486,7 @@ stages:
           homedir: "/home/testuser"
 ```
 
-This configuration can be either manually copied over, or can be propagated also via Kubernetes using the system upgrade controller. See [the after-install](/docs/advanced/after-install) section for an example.
+This configuration can be either manually copied over, or can be propagated also via Kubernetes using the system upgrade controller. See [the after-install]({{< ref "../advanced/after-install" >}}) section for an example.
 
 ```bash
 ❯ ssh testuser@192.168.1.238
@@ -509,7 +509,7 @@ P2P functionalities are experimental Kairos features and disabled by default. In
 
 ### `p2p.network_token`
 
-This defines the network token used by peers to join the p2p virtual private network. You can generate it with the Kairos CLI with `kairos generate-token`. Check out [the P2P section](/docs/installation/p2p) for more instructions.
+This defines the network token used by peers to join the p2p virtual private network. You can generate it with the Kairos CLI with `kairos generate-token`. Check out [the P2P section]({{< ref "../installation/p2p" >}}) for more instructions.
 
 ### `p2p.role`
 
@@ -553,7 +553,7 @@ p2p:
 
 ## Stages
 
-The `stages` key is a map that allows to execute blocks of cloud-init directives during the lifecycle of the node [stages](/docs/architecture/cloud-init).
+The `stages` key is a map that allows to execute blocks of cloud-init directives during the lifecycle of the node [stages]({{< ref "../architecture/cloud-init" >}}).
 
 A full example of a stage is the following:
 

--- a/content/en/docs/Reference/configuration.md
+++ b/content/en/docs/Reference/configuration.md
@@ -192,7 +192,7 @@ Kairos supports a portion of the standard [cloud-init](https://cloud-init.io/) s
 
 Examples using the extended notation for running K3s as agent or server can be found in the [examples](https://github.com/kairos-io/kairos/tree/master/examples)  directory of the Kairos repository.
 
-Here's an example that shows how to set up DNS at the [boot stage]({{< ref "../architecture/cloud-init" >}}) using the extended syntax:
+Here's an example that shows how to set up DNS at the [boot stage]({{< relref "../architecture/cloud-init" >}}) using the extended syntax:
 
 ```yaml
 #cloud-config
@@ -363,7 +363,7 @@ k3s-agent:
 {{% /tab %}}
 {{< /tabpane >}}
 
-For more examples of how to configure K3s manually, see the [examples]({{< ref "../examples" >}}) section or [HA]({{< ref "../examples/ha" >}}).
+For more examples of how to configure K3s manually, see the [examples]({{< relref "../examples" >}}) section or [HA]({{< relref "../examples/ha" >}}).
 
 ### Grub options
 
@@ -486,7 +486,7 @@ stages:
           homedir: "/home/testuser"
 ```
 
-This configuration can be either manually copied over, or can be propagated also via Kubernetes using the system upgrade controller. See [the after-install]({{< ref "../advanced/after-install" >}}) section for an example.
+This configuration can be either manually copied over, or can be propagated also via Kubernetes using the system upgrade controller. See [the after-install]({{< relref "../advanced/after-install" >}}) section for an example.
 
 ```bash
 ❯ ssh testuser@192.168.1.238
@@ -509,7 +509,7 @@ P2P functionalities are experimental Kairos features and disabled by default. In
 
 ### `p2p.network_token`
 
-This defines the network token used by peers to join the p2p virtual private network. You can generate it with the Kairos CLI with `kairos generate-token`. Check out [the P2P section]({{< ref "../installation/p2p" >}}) for more instructions.
+This defines the network token used by peers to join the p2p virtual private network. You can generate it with the Kairos CLI with `kairos generate-token`. Check out [the P2P section]({{< relref "../installation/p2p" >}}) for more instructions.
 
 ### `p2p.role`
 
@@ -553,7 +553,7 @@ p2p:
 
 ## Stages
 
-The `stages` key is a map that allows to execute blocks of cloud-init directives during the lifecycle of the node [stages]({{< ref "../architecture/cloud-init" >}}).
+The `stages` key is a map that allows to execute blocks of cloud-init directives during the lifecycle of the node [stages]({{< relref "../architecture/cloud-init" >}}).
 
 A full example of a stage is the following:
 

--- a/content/en/docs/Reference/entangle.md
+++ b/content/en/docs/Reference/entangle.md
@@ -75,7 +75,7 @@ They both need to agree on a secret, which is the `network_token` to be able to 
 
 ### Generating a network token
 
-Generating a network token is described in [the p2p section](/docs/installation/p2p)
+Generating a network token is described in [the p2p section]({{< ref "../installation/p2p" >}})
 
 ### Managed cluster
 

--- a/content/en/docs/Reference/entangle.md
+++ b/content/en/docs/Reference/entangle.md
@@ -75,7 +75,7 @@ They both need to agree on a secret, which is the `network_token` to be able to 
 
 ### Generating a network token
 
-Generating a network token is described in [the p2p section]({{< ref "../installation/p2p" >}})
+Generating a network token is described in [the p2p section]({{< relref "../installation/p2p" >}})
 
 ### Managed cluster
 

--- a/content/en/docs/Reference/faq.md
+++ b/content/en/docs/Reference/faq.md
@@ -8,7 +8,7 @@ description: >
 
 ## What is the difference between Kairos compared to Talos/Sidero Metal and Flatcar?
 
-Kairos is distro-agnostic by design. Currently, you can pick among a list from the [supported matrix](/docs/reference/image_matrix/#image-flavors), but we are working on CRDs to let assemble OSes from other bases in a Kubernetes native way.
+Kairos is distro-agnostic by design. Currently, you can pick among a list from the [supported matrix]({{< ref "../reference/image_matrix#image-flavors" >}}), but we are working on CRDs to let assemble OSes from other bases in a Kubernetes native way.
 
 The key difference, is that the OS is distributed as a standard container, similar to how apps are distributed with container registries. You can also use `docker run` locally and inspect the OS, and similarly, push customizations by pointing nodes to a new image.
 
@@ -16,7 +16,7 @@ Also, Kairos is easy to setup. The P2P capabilities allow nodes to self-coordina
 
 ## What would be the difference between Kairos and Fedora Coreos?
 
-Kairos is distribution agnostic. It supports all the distributions in the [supported matrix](/docs/reference/image_matrix/#image-flavors). In addition, we plan to have K3s automatically deploy Kubernetes (even by self-coordinating nodes).
+Kairos is distribution agnostic. It supports all the distributions in the [supported matrix]({{< ref "../reference/image_matrix#image-flavors" >}}). In addition, we plan to have K3s automatically deploy Kubernetes (even by self-coordinating nodes).
 
 Additionally, Kairos is OCI-based, and the system is based from a container image. This makes it possible to also run it locally with `docker run` to inspect it, as well to customize and upgrade your nodes by just pointing at it. Think of it like containers apps, but bootable.
 

--- a/content/en/docs/Reference/faq.md
+++ b/content/en/docs/Reference/faq.md
@@ -8,7 +8,7 @@ description: >
 
 ## What is the difference between Kairos compared to Talos/Sidero Metal and Flatcar?
 
-Kairos is distro-agnostic by design. Currently, you can pick among a list from the [supported matrix]({{< ref "../reference/image_matrix#image-flavors" >}}), but we are working on CRDs to let assemble OSes from other bases in a Kubernetes native way.
+Kairos is distro-agnostic by design. Currently, you can pick among a list from the [supported matrix]({{< relref "../reference/image_matrix#image-flavors" >}}), but we are working on CRDs to let assemble OSes from other bases in a Kubernetes native way.
 
 The key difference, is that the OS is distributed as a standard container, similar to how apps are distributed with container registries. You can also use `docker run` locally and inspect the OS, and similarly, push customizations by pointing nodes to a new image.
 
@@ -16,7 +16,7 @@ Also, Kairos is easy to setup. The P2P capabilities allow nodes to self-coordina
 
 ## What would be the difference between Kairos and Fedora Coreos?
 
-Kairos is distribution agnostic. It supports all the distributions in the [supported matrix]({{< ref "../reference/image_matrix#image-flavors" >}}). In addition, we plan to have K3s automatically deploy Kubernetes (even by self-coordinating nodes).
+Kairos is distribution agnostic. It supports all the distributions in the [supported matrix]({{< relref "../reference/image_matrix#image-flavors" >}}). In addition, we plan to have K3s automatically deploy Kubernetes (even by self-coordinating nodes).
 
 Additionally, Kairos is OCI-based, and the system is based from a container image. This makes it possible to also run it locally with `docker run` to inspect it, as well to customize and upgrade your nodes by just pointing at it. Think of it like containers apps, but bootable.
 

--- a/content/en/docs/Reference/image_matrix.md
+++ b/content/en/docs/Reference/image_matrix.md
@@ -10,7 +10,7 @@ Kairos offers several pre-built images for user convenience based on popular Lin
 
 In addition, tighter integration with systemd allows for several features that are only available with it, such as live layering.
 
-These images are pushed to quay.io and are available for installation and upgrading. The installable mediums included in the releases are generated using the methods described in the [automated installation reference]({{< ref "../installation/automated#iso-remastering" >}}), and the images can be used for upgrades as well.
+These images are pushed to quay.io and are available for installation and upgrading. The installable mediums included in the releases are generated using the methods described in the [automated installation reference]({{< relref "../installation/automated#iso-remastering" >}}), and the images can be used for upgrades as well.
 
 ## Image flavors
 
@@ -19,7 +19,7 @@ Kairos release processes generates images based on official container images fro
 Below is a list of the available images and their locations on the quay.io registry:
 
 - The **Core** images do not include any Kubernetes engine and can be used as a base for customizations.
-- The **Standard** images include `k3s` and the [kairos provider](https://github.com/kairos-io/provider-kairos), which enables Kubernetes deployments and optionally enables [p2p]({{< ref "../installation/p2p" >}}).
+- The **Standard** images include `k3s` and the [kairos provider](https://github.com/kairos-io/provider-kairos), which enables Kubernetes deployments and optionally enables [p2p]({{< relref "../installation/p2p" >}}).
 - The **-img** repositories contain an img file which can be directly written to an SD card or USB drive for use with ARM devices.
 
 Base images are tagged with specific upstream versions (e.g. Ubuntu 20 LTS is pinned to Ubuntu 20:04, openSUSE to openSUSE leap 15.4, etc.).
@@ -108,7 +108,7 @@ The artifacts can be found in the `build` directory.
 
 ### Framework images
 
-Kairos releases contains also the __framework__ assets that can be used to [build Kairos images from Scratch]({{< ref "../reference/build-from-scratch" >}}).
+Kairos releases contains also the __framework__ assets that can be used to [build Kairos images from Scratch]({{< relref "../reference/build-from-scratch" >}}).
 
 Framework images can be found in quay at: https://quay.io/repository/kairos/framework.
 
@@ -127,7 +127,7 @@ Here are some key points to note:
 {{% alert title="Note" color="info" %}}
 In order to give users more control over the chosen base image (e.g. `openSUSE`, `Ubuntu`, etc.) and reduce reliance on our CI infrastructure, we are actively working on streamlining the creation of Kairos-based distributions directly from upstream base images. You can track the development progress [here](https://github.com/kairos-io/kairos/issues/116).
 
-If you need to further customize images, including changes to the base image, package updates, and CVE hotfixes, check out the [customization docs]({{< ref "../advanced/customizing" >}}).
+If you need to further customize images, including changes to the base image, package updates, and CVE hotfixes, check out the [customization docs]({{< relref "../advanced/customizing" >}}).
 {{% /alert %}}
 
 

--- a/content/en/docs/Reference/image_matrix.md
+++ b/content/en/docs/Reference/image_matrix.md
@@ -10,7 +10,7 @@ Kairos offers several pre-built images for user convenience based on popular Lin
 
 In addition, tighter integration with systemd allows for several features that are only available with it, such as live layering.
 
-These images are pushed to quay.io and are available for installation and upgrading. The installable mediums included in the releases are generated using the methods described in the [automated installation reference](/docs/installation/automated/#iso-remastering), and the images can be used for upgrades as well.
+These images are pushed to quay.io and are available for installation and upgrading. The installable mediums included in the releases are generated using the methods described in the [automated installation reference]({{< ref "../installation/automated#iso-remastering" >}}), and the images can be used for upgrades as well.
 
 ## Image flavors
 
@@ -19,7 +19,7 @@ Kairos release processes generates images based on official container images fro
 Below is a list of the available images and their locations on the quay.io registry:
 
 - The **Core** images do not include any Kubernetes engine and can be used as a base for customizations.
-- The **Standard** images include `k3s` and the [kairos provider](https://github.com/kairos-io/provider-kairos), which enables Kubernetes deployments and optionally enables [p2p](/docs/installation/p2p).
+- The **Standard** images include `k3s` and the [kairos provider](https://github.com/kairos-io/provider-kairos), which enables Kubernetes deployments and optionally enables [p2p]({{< ref "../installation/p2p" >}}).
 - The **-img** repositories contain an img file which can be directly written to an SD card or USB drive for use with ARM devices.
 
 Base images are tagged with specific upstream versions (e.g. Ubuntu 20 LTS is pinned to Ubuntu 20:04, openSUSE to openSUSE leap 15.4, etc.).
@@ -108,7 +108,7 @@ The artifacts can be found in the `build` directory.
 
 ### Framework images
 
-Kairos releases contains also the __framework__ assets that can be used to [build Kairos images from Scratch](/docs/reference/build-from-scratch).
+Kairos releases contains also the __framework__ assets that can be used to [build Kairos images from Scratch]({{< ref "../reference/build-from-scratch" >}}).
 
 Framework images can be found in quay at: https://quay.io/repository/kairos/framework.
 
@@ -127,7 +127,7 @@ Here are some key points to note:
 {{% alert title="Note" color="info" %}}
 In order to give users more control over the chosen base image (e.g. `openSUSE`, `Ubuntu`, etc.) and reduce reliance on our CI infrastructure, we are actively working on streamlining the creation of Kairos-based distributions directly from upstream base images. You can track the development progress [here](https://github.com/kairos-io/kairos/issues/116).
 
-If you need to further customize images, including changes to the base image, package updates, and CVE hotfixes, check out the [customization docs](/docs/advanced/customizing).
+If you need to further customize images, including changes to the base image, package updates, and CVE hotfixes, check out the [customization docs]({{< ref "../advanced/customizing" >}}).
 {{% /alert %}}
 
 

--- a/content/en/docs/Upgrade/kubernetes.md
+++ b/content/en/docs/Upgrade/kubernetes.md
@@ -112,7 +112,7 @@ spec:
                 url: https://rekor.sigstore.dev
 ```
 
-To install Kyverno in a Kairos cluster, you can simply use the community [bundles](/docs/advanced/bundles). For example, you can use the following installation cloud config file:
+To install Kyverno in a Kairos cluster, you can simply use the community [bundles]({{< ref "../advanced/bundles" >}}). For example, you can use the following installation cloud config file:
 
 ```yaml
 #cloud-config
@@ -243,6 +243,6 @@ spec:
 
 ## What's next?
 
-- [Upgrade nodes manually](/docs/upgrade/manual)
-- [Immutable architecture](/docs/architecture/immutable)
-- [Create decentralized clusters](/docs/installation/p2p)
+- [Upgrade nodes manually]({{< ref "../upgrade/manual" >}})
+- [Immutable architecture]({{< ref "../architecture/immutable" >}})
+- [Create decentralized clusters]({{< ref "../installation/p2p" >}})

--- a/content/en/docs/Upgrade/kubernetes.md
+++ b/content/en/docs/Upgrade/kubernetes.md
@@ -112,7 +112,7 @@ spec:
                 url: https://rekor.sigstore.dev
 ```
 
-To install Kyverno in a Kairos cluster, you can simply use the community [bundles]({{< ref "../advanced/bundles" >}}). For example, you can use the following installation cloud config file:
+To install Kyverno in a Kairos cluster, you can simply use the community [bundles]({{< relref "../advanced/bundles" >}}). For example, you can use the following installation cloud config file:
 
 ```yaml
 #cloud-config
@@ -243,6 +243,6 @@ spec:
 
 ## What's next?
 
-- [Upgrade nodes manually]({{< ref "../upgrade/manual" >}})
-- [Immutable architecture]({{< ref "../architecture/immutable" >}})
-- [Create decentralized clusters]({{< ref "../installation/p2p" >}})
+- [Upgrade nodes manually]({{< relref "../upgrade/manual" >}})
+- [Immutable architecture]({{< relref "../architecture/immutable" >}})
+- [Create decentralized clusters]({{< relref "../installation/p2p" >}})

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -14,21 +14,21 @@ Kairos is the open-source project that simplifies Edge, cloud, and bare metal OS
 
 Our key features include:
 
-- [Immutability](/docs/architecture/immutable): ensure your infrastructure stays consistent with atomic upgrades
+- [Immutability]({{< ref "architecture/immutable" >}}): ensure your infrastructure stays consistent with atomic upgrades
 - Security: protect your cluster from vulnerabilities and attacks with a read-only system
-- [Container-based](/docs/architecture/container): manage your nodes as apps in containers for maximum flexibility and portability
-- [P2P Mesh](/docs/architecture/network): self-coordinated, automated, no interaction Kubernetes deployments with P2P
-- [Meta-Distribution](/docs/architecture/meta), distro agnostic
+- [Container-based]({{< ref "architecture/container" >}}): manage your nodes as apps in containers for maximum flexibility and portability
+- [P2P Mesh]({{< ref "architecture/network" >}}): self-coordinated, automated, no interaction Kubernetes deployments with P2P
+- [Meta-Distribution]({{< ref "architecture/meta" >}}), distro agnostic
 
 
 In this documentation, you will find everything you need to know about Kairos, from installation and configuration, to examples and advanced features.
 
-To get started with Kairos, follow the instructions in the [quickstart](/docs/getting-started) guide. Then, check out the [examples](/docs/examples) to see how Kairos can be used in real-world scenarios.
+To get started with Kairos, follow the instructions in the [quickstart]({{< ref "Getting started" >}}) guide. Then, check out the [examples]({{< ref "examples" >}}) to see how Kairos can be used in real-world scenarios.
 
 For more information, please refer to this documentation. If you have any questions or feedback, feel free to [open an issue](https://github.com/kairos-io/kairos/issues/new) or [join our community forum](https://github.com/kairos-io/kairos/discussions).
 
 {{% alert title="Note" %}}
-You can also find some good resources on the [Media Section]({{< ref "docs/media" >}} "Media")
+You can also find some good resources on the [Media Section]({{< ref "media" >}} "Media")
 {{% /alert %}}
 
 ## What is Kairos ?
@@ -140,4 +140,4 @@ Run `./earthly.sh +all --FLAVOR=opensuse`, should produce a Docker image along w
 
 ## What's next?
 
-See the [quickstart](/docs/getting-started) to install Kairos on a VM and create a Kubernetes cluster!
+See the [quickstart]({{< ref "Getting started" >}}) to install Kairos on a VM and create a Kubernetes cluster!

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -14,21 +14,21 @@ Kairos is the open-source project that simplifies Edge, cloud, and bare metal OS
 
 Our key features include:
 
-- [Immutability]({{< ref "architecture/immutable" >}}): ensure your infrastructure stays consistent with atomic upgrades
+- [Immutability]({{< relref "architecture/immutable" >}}): ensure your infrastructure stays consistent with atomic upgrades
 - Security: protect your cluster from vulnerabilities and attacks with a read-only system
-- [Container-based]({{< ref "architecture/container" >}}): manage your nodes as apps in containers for maximum flexibility and portability
-- [P2P Mesh]({{< ref "architecture/network" >}}): self-coordinated, automated, no interaction Kubernetes deployments with P2P
-- [Meta-Distribution]({{< ref "architecture/meta" >}}), distro agnostic
+- [Container-based]({{< relref "architecture/container" >}}): manage your nodes as apps in containers for maximum flexibility and portability
+- [P2P Mesh]({{< relref "architecture/network" >}}): self-coordinated, automated, no interaction Kubernetes deployments with P2P
+- [Meta-Distribution]({{< relref "architecture/meta" >}}), distro agnostic
 
 
 In this documentation, you will find everything you need to know about Kairos, from installation and configuration, to examples and advanced features.
 
-To get started with Kairos, follow the instructions in the [quickstart]({{< ref "Getting started" >}}) guide. Then, check out the [examples]({{< ref "examples" >}}) to see how Kairos can be used in real-world scenarios.
+To get started with Kairos, follow the instructions in the [quickstart]({{< relref "Getting started" >}}) guide. Then, check out the [examples]({{< relref "examples" >}}) to see how Kairos can be used in real-world scenarios.
 
 For more information, please refer to this documentation. If you have any questions or feedback, feel free to [open an issue](https://github.com/kairos-io/kairos/issues/new) or [join our community forum](https://github.com/kairos-io/kairos/discussions).
 
 {{% alert title="Note" %}}
-You can also find some good resources on the [Media Section]({{< ref "media" >}} "Media")
+You can also find some good resources on the [Media Section]({{< relref "media" >}} "Media")
 {{% /alert %}}
 
 ## What is Kairos ?
@@ -140,4 +140,4 @@ Run `./earthly.sh +all --FLAVOR=opensuse`, should produce a Docker image along w
 
 ## What's next?
 
-See the [quickstart]({{< ref "Getting started" >}}) to install Kairos on a VM and create a Kubernetes cluster!
+See the [quickstart]({{< relref "Getting started" >}}) to install Kairos on a VM and create a Kubernetes cluster!


### PR DESCRIPTION
Instead of pointing to the base_url + /docs/ as default. This should make the documentation work anywhere, no matter if we change the dir in which the docs are contained as they are referencing by relative paths

This also has the advantage that hugo will check the validity of the links on compilation and fail if a link points to nowhere