### PR TITLE
Improve sidebar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -128,6 +128,8 @@ registryURL = "quay.io/kairos"
 [params.ui]
 # Enable to show the side bar menu in its compact state.
 sidebar_menu_compact = true
+# Enable to show the foldable triangle
+sidebar_menu_foldable = true
 #  Set to true to disable breadcrumb navigation.
 breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)

--- a/config.toml
+++ b/config.toml
@@ -127,9 +127,9 @@ registryURL = "quay.io/kairos"
 # User interface configuration
 [params.ui]
 # Enable to show the side bar menu in its compact state.
-sidebar_menu_compact = false
+sidebar_menu_compact = true
 #  Set to true to disable breadcrumb navigation.
-breadcrumb_disable = true
+breadcrumb_disable = false
 #  Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
 sidebar_search_disable = true
 #  Set to false if you don't want to display a logo (/assets/icons/logo.svg) in the top nav bar

--- a/content/en/docs/Advanced/_index.md
+++ b/content/en/docs/Advanced/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Advanced"
 linkTitle: "Advanced"
+icon: fa-regular fa-gear
 weight: 5
 description: >
   Advanced settings

--- a/content/en/docs/Architecture/_index.md
+++ b/content/en/docs/Architecture/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Architecture"
 linkTitle: "Architecture"
+icon: fa-regular fa-diagram-project
 weight: 4
 description: >
 ---

--- a/content/en/docs/Development/_index.md
+++ b/content/en/docs/Development/_index.md
@@ -2,5 +2,6 @@
 title: "Development"
 linkTitle: "Development"
 weight: 7
+icon: fa-regular fa-terminal
 description: >
 ---

--- a/content/en/docs/Examples/_index.md
+++ b/content/en/docs/Examples/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Examples"
 linkTitle: "Examples"
+icon: fa-regular fa-file
 weight: 5
 description: > 
     This section contains various examples, how-to and tutorial to use Kairos

--- a/content/en/docs/Getting started/_index.md
+++ b/content/en/docs/Getting started/_index.md
@@ -2,6 +2,7 @@
 title: "Getting Started"
 linkTitle: "Getting Started"
 weight: 2
+icon: fa-regular fa-flag-checkered
 description: >
   Getting started with Kairos
 ---

--- a/content/en/docs/Installation/_index.md
+++ b/content/en/docs/Installation/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Installation"
 linkTitle: "Installation"
+icon: fa-regular fa-computer
 weight: 2
 description: >
   Kairos Installation reference

--- a/content/en/docs/Media/_index.md
+++ b/content/en/docs/Media/_index.md
@@ -2,6 +2,7 @@
 title: "Media"
 linkTitle: "Media"
 weight: 9
+icon: fa-regular fa-circle-play
 description: >
   Presentation Slides, Videos and other media on Kairos
 ---

--- a/content/en/docs/Reference/_index.md
+++ b/content/en/docs/Reference/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Reference"
 linkTitle: "Reference"
+icon: fa-regular fa-book
 weight: 6
 description: >
 ---

--- a/content/en/docs/Upgrade/_index.md
+++ b/content/en/docs/Upgrade/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Upgrade"
 linkTitle: "Upgrade"
+icon: fa-regular fa-cloud-arrow-up
 weight: 3
 description: >
 ---


### PR DESCRIPTION
Adds icons to each entry
Nav bar is collapsed by default as it now covers the full side on any monitor and hides part of the docs