### PR TITLE
:sparkles: Convert docsy to a go module

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -6,6 +6,8 @@ docs:
     FROM node:19-bullseye
     ARG TARGETARCH
 
+    RUN apt update && apt install -y golang
+
     # Install dependencies
     RUN apt install git
     # renovate: datasource=github-releases depName=gohugoio/hugo
@@ -19,7 +21,6 @@ docs:
     WORKDIR ./docs
 
     RUN npm install postcss-cli
-    RUN npm run prepare
 
     RUN HUGO_ENV="production" /usr/bin/hugo --gc -b "/local/" -d "public/"
     SAVE ARTIFACT public /public AS LOCAL docs/

--- a/config.toml
+++ b/config.toml
@@ -4,7 +4,7 @@ title = "Kairos"
 enableRobotsTXT = true
 
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
-theme = ["docsy"]
+theme = ["github.com/google/docsy", "github.com/google/docsy/dependencies"]
 
 # Will give values to .Lastmod etc.
 enableGitInfo = true

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/kairos-io/kairos-docs
 
 go 1.20
+
+require github.com/google/docsy v0.7.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/kairos-io/kairos-docs
 
 go 1.20
 
-require github.com/google/docsy v0.7.1 // indirect
+require (
+	github.com/google/docsy v0.7.1 // indirect
+	github.com/google/docsy/dependencies v0.7.1 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kairos-io/kairos-docs
+
+go 1.20

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,5 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.7.1 h1:DUriA7Nr3lJjNi9Ulev1SfiG1sUYmvyDeU4nTp7uDxY=
+github.com/google/docsy v0.7.1/go.mod h1:JCmE+c+izhE0Rvzv3y+AzHhz1KdwlA9Oj5YBMklJcfc=
+github.com/google/docsy/dependencies v0.7.1/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
+github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy v0.7.1 h1:DUriA7Nr3lJjNi9Ulev1SfiG1sUYmvyDeU4nTp7uDxY=
 github.com/google/docsy v0.7.1/go.mod h1:JCmE+c+izhE0Rvzv3y+AzHhz1KdwlA9Oj5YBMklJcfc=
+github.com/google/docsy/dependencies v0.7.1 h1:NbzYKJYMin2q50xdWSUzR2c9gCp7zR/XHDBcxklEcTQ=
 github.com/google/docsy/dependencies v0.7.1/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/package.json
+++ b/package.json
@@ -3,10 +3,5 @@
     "autoprefixer": "^10.4.13",
     "postcss": "^8.4.21",
     "postcss-cli": "^10.1.0"
-  },
-  "scripts": {
-    "get:submodule": "git submodule update --init --depth 1",
-    "_prepare:docsy": "cd themes/docsy && npm install",
-    "prepare": "npm run get:submodule && npm run _prepare:docsy"
   }
 }


### PR DESCRIPTION
We had a couple of issues with the homepage revamp because of the git submodule, so would rather use a go module for docsy installation.

Need to test how it works with creating docs for the agent still