### PR TITLE
Link to wifi example and add shortcode to include remote source

### DIFF
--- a/content/en/docs/Examples/wifi.md
+++ b/content/en/docs/Examples/wifi.md
@@ -1,0 +1,16 @@
+---
+title: "Configuring wifi via cloud-config"
+linkTitle: "Configuring wifi via cloud-config"
+weight: 1
+description: > 
+---
+
+
+This example is valid for systemd-based systems.
+
+{{< getRemoteSource "https://raw.githubusercontent.com/kairos-io/kairos/master/examples/cloud-configs/wifi.yaml" >}}
+
+
+{{% alert title="Note" color="info" %}}
+This is only an example as there is many ways of configuring wifi via cloud config depending on the software installed on the image
+{{% /alert %}}

--- a/layouts/shortcodes/getRemoteSource.html
+++ b/layouts/shortcodes/getRemoteSource.html
@@ -1,0 +1,5 @@
+<!-- This shortcode accepts a remote url and gets its content, extracts the extensions and returns a neatly formatted source output -->
+{{- $url := .Get 0 -}}
+{{- $remote := resources.GetRemote $url -}}
+{{- $fileExt := replace (index (findRE "(\\.)\\w+$" $remote) 0) "." "" -}}
+<pre><code class="language-{{ $fileExt }}">{{- $remote.Content -}}</code></pre>


### PR DESCRIPTION
This allows us to include the examples directly from the kairos repo if needed