### PR TITLE
kairosctl download link fix.

### DIFF
--- a/content/en/docs/Getting started/_index.md
+++ b/content/en/docs/Getting started/_index.md
@@ -234,7 +234,7 @@ You can find instructions showing how to use the Kairos CLI below. In case you p
 To trigger the installation process via QR code, you need to use the Kairos CLI. The CLI is currently available only for Linux and Windows. It can be downloaded from the release artifact:
 
 ```bash
-curl -L https://github.com/kairos-io/provider-kairos/releases/download/{{<providerVersion>}}/kairosctl-v{{<providerVersion>}}-linux-amd64.tar.gz -o - | tar -xvzf - -C .
+curl -L https://github.com/kairos-io/provider-kairos/releases/download/{{<providerVersion>}}/kairosctl-{{<providerVersion>}}-linux-amd64.tar.gz -o - | tar -xvzf - -C .
 ```
 
 ```bash

--- a/content/en/docs/Getting started/_index.md
+++ b/content/en/docs/Getting started/_index.md
@@ -234,7 +234,7 @@ You can find instructions showing how to use the Kairos CLI below. In case you p
 To trigger the installation process via QR code, you need to use the Kairos CLI. The CLI is currently available only for Linux and Windows. It can be downloaded from the release artifact:
 
 ```bash
-curl -L https://github.com/kairos-io/provider-kairos/releases/download/{{<providerVersion>}}/kairosctl-.{{<providerVersion>}}-.linux-.amd64.tar.gz -o - | tar -xvzf - -C .
+curl -L https://github.com/kairos-io/provider-kairos/releases/download/{{<providerVersion>}}/kairosctl-v{{<providerVersion>}}-linux-amd64.tar.gz -o - | tar -xvzf - -C .
 ```
 
 ```bash


### PR DESCRIPTION
Literally just changed a single line.

curl -L https://github.com/kairos-io/provider-kairos/releases/download/{{<providerVersion>}}/kairosctl-v{{<providerVersion>}}-linux-amd64.tar.gz -o - | tar -xvzf - -C .

instead of:

curl -L https://github.com/kairos-io/provider-kairos/releases/download/{{<providerVersion>}}/kairosctl-.{{<providerVersion>}}-.linux-.amd64.tar.gz -o - | tar -xvzf - -C .

------------------------------------------------------------------------------------------------------------------------

Tried to download, but got these errors:

$ curl -L https://github.com/kairos-io/provider-kairos/releases/download/v2.6.3/kairosctl-.v2.6.3-.linux-.amd64.tar.gz -o - | tar -xvzf - -C .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     9  100     9    0     0     46      0 --:--:-- --:--:-- --:--:--    46

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now

$ file kairosctl-.v2.6.3-.linux-.amd64.tar.gz
kairosctl-.v2.6.3-.linux-.amd64.tar.gz: ASCII text, with no line terminators