### PR TITLE
fix: image shortcode

### DIFF
--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -27,7 +27,7 @@ kairos-
 -
 {{- $.Page.Site.Params.softwareVersions.kairos_version -}}
 {{- if eq (.Get "variant") "standard" -}}
-    -k3s{{- replace $.Page.Site.Params.softwareVersions.k3s_version "+" "-" -}}
+    -k3s{{$.Page.Site.Params.softwareVersions.k3s_version | safeHTML }}
 {{- end -}}
 {{- with .Get "suffix" -}}
     -{{- . -}}


### PR DESCRIPTION
Current documentation points to https://github.com/kairos-io/kairos/releases/download/v3.0.4/kairos-opensuse-leap-15.5-standard-amd64-generic-v3.0.4-k3sv1.29.3-k3s1.iso here, https://kairos.io/docs/getting-started/#download. 

This is because when trying to replace `+` with `-`, the endpoint made does not exist.

Since `k3s_version` is equal to `v1.29.3+k3s1`, keeping `+` would output it as `v1.29.3&#43;k3s1` which is also incorrect, the way I fix this is by adding `safeHTML`, https://gohugo.io/functions/safe/html/.