### PR TITLE
Add outbound links and downloads tracking

### DIFF
--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -1,1 +1,1 @@
-<script defer data-domain="kairos.io" src="https://plausible.io/js/script.js"></script>
+<script defer data-domain="kairos.io" src="https://plausible.io/js/script.outbound-links.file-downloads.js"></script>


### PR DESCRIPTION
This allows us to check which links outside kairos.io are users clicking the most on. The idea is to measure how well our strategies to link to github, quay or any other are working. It also adds the download tracking, I'm not sure if this one will work as expected since none of our files are under kairos.io domain but I want to try it out