### PR TITLE
Clarify kairos user can always sudo

### DIFF
--- a/content/en/docs/Reference/configuration.md
+++ b/content/en/docs/Reference/configuration.md
@@ -588,7 +588,7 @@ Kairos comes with the `kairos` user pre-configured, however, it is possible to c
 
 ### Add a user during first-install
 
-Consider the following example cloud-config, which adds the `testuser` user to the system with admin access:
+Consider the following example cloud-config, containing the default `kairos` user (which always has sudo access) and adds the `testuser` user to the system with admin access:
 
 ```yaml
 #cloud-config


### PR DESCRIPTION
This is mentioned in getting started, but thought it would be useful to clarify here