### PR TITLE
Replace install.image with install.source in docs

### DIFF
--- a/content/en/docs/Examples/core.md
+++ b/content/en/docs/Examples/core.md
@@ -19,7 +19,7 @@ For example, let's say you want to use a standard image. Your cloud config file 
 #cloud-config
 install:
  # Here we specify the image that we want to deploy
- image: "docker:{{<oci variant="standard">}}"
+ source: "docker:{{<oci variant="standard">}}"
 ```
 
 {{% alert title="Note" %}}

--- a/content/en/docs/Reference/configuration.md
+++ b/content/en/docs/Reference/configuration.md
@@ -120,7 +120,7 @@ install:
   # recovery-system.size: 5000
   
   # Use a different container image for the installation
-  image: "docker:.."
+  source: "docker:.."
   # Add bundles in runtime
   bundles:
     - ...


### PR DESCRIPTION
because the old option is deprecated

Fixes https://github.com/kairos-io/kairos/issues/2810