### PR TITLE
fix: update twitter icon to x

### DIFF
--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -191,7 +191,7 @@
                     </div>
                 </a>
                 <a href="https://twitter.com/Kairos_OSS" target="_blank">
-                    <i class="fa-brands fa-twitter"></i>
+                    <i class="fa-brands fa-x-twitter"></i>
                     <div>
                         <p>Follow us <br> on Twitter</p>
                     </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,7 +9,7 @@
             <div class="footer-follow-us">Follow us
                 <div>
                     <a href="https://twitter.com/Kairos_OSS" target="_blank">
-                        <i class="fa-brands fa-twitter"></i>
+                        <i class="fa-brands fa-x-twitter"></i>
                     </a>
                     <a href="https://github.com/kairos-io/kairos" target="_blank">
                         <i class="fa-brands fa-github"></i>


### PR DESCRIPTION
The Twitter logo has been changed and hasn't been updated on the docs site https://kairos.io/ [Fixes #295].
After changes
<img width="999" alt="Screenshot 2024-10-20 at 3 11 47 PM" src="https://github.com/user-attachments/assets/9f754dc7-a946-4354-8e45-ba73f8c7265f">
<img width="230" alt="Screenshot 2024-10-20 at 3 11 50 PM" src="https://github.com/user-attachments/assets/42b71932-a8b4-40ac-bef3-4495dc509300">
