### PR TITLE
removing outdated alert

### DIFF
--- a/content/en/docs/Architecture/cloud-init.md
+++ b/content/en/docs/Architecture/cloud-init.md
@@ -20,8 +20,8 @@ By using the standard cloud-config syntax, a subset of the functionalities are a
 
 ### Configuration order
 
-When an action is done (install, upgrade, reset) several default dirs in the system are read to obtain the configuration and are merged together.
-The dirs and the order in which they are read and merged, is as shown below, from first to last. Notice that any values found in different dirs will override existing ones in previous dirs.
+When an action is done (install, upgrade, reset) several default directories in the system are read to obtain the configuration and are merged together.
+The directories and the order in which they are read and merged, is as shown below, from first to last. Notice that any values found in different directories will override existing ones in previous directories.
 
  - /run/initramfs/live (Only available on LiveCD/Netboot)
  - /usr/local/cloud-config
@@ -51,7 +51,7 @@ stages:
    before-reset:
      - name: "Setting"
        commands:
-       - | 
+       - |
           echo "Run a command before reset the node!"
 
 ```
@@ -68,12 +68,12 @@ Below there is a detailed list of the stages available that can be used in the c
 | _reconcile_                | This stage is executed 5m after boot and periodically each 60m.                                                                                                                                                                                                                     |
 | _kairos-install.pre_       | This stage is executed before installation of the OS starts                                                                                                                                                                                                                         |
 | _kairos-uki-install.pre_   | This stage is executed before installation of the OS starts. Only run under Trusted Boot                                                                                                                                                                                            |
-| _kairos-install.after_     | This stage is executed after installation of the OS ends                                                                                                                                                                                                                            |                         
-| _kairos-uki-install.after_ | This stage is executed after installation of the OS ends. Only run under Trusted Boot                                                                                                                                                                                               |                         
-| _kairos-uki-reset.pre_     | This stage is executed before reset. Only run under Trusted Boot                                                                                                                                                                                                                    |                         
-| _kairos-uki-reset.after_   | This stage is executed after reset. Only run under Trusted Boot                                                                                                                                                                                                                     |                       
-| _kairos-uki-upgrade.pre_   | This stage is executed before upgrade. Only run under Trusted Boot                                                                                                                                                                                                                  |                       
-| _kairos-uki-upgrade.after_ | This stage is executed after upgrade. Only run under Trusted Boot                                                                                                                                                                                                                   |                       
+| _kairos-install.after_     | This stage is executed after installation of the OS ends                                                                                                                                                                                                                            |
+| _kairos-uki-install.after_ | This stage is executed after installation of the OS ends. Only run under Trusted Boot                                                                                                                                                                                               |
+| _kairos-uki-reset.pre_     | This stage is executed before reset. Only run under Trusted Boot                                                                                                                                                                                                                    |
+| _kairos-uki-reset.after_   | This stage is executed after reset. Only run under Trusted Boot                                                                                                                                                                                                                     |
+| _kairos-uki-upgrade.pre_   | This stage is executed before upgrade. Only run under Trusted Boot                                                                                                                                                                                                                  |
+| _kairos-uki-upgrade.after_ | This stage is executed after upgrade. Only run under Trusted Boot                                                                                                                                                                                                                   |
 | _before-install_           | This stage happens after partitioning but before the image OS is applied                                                                                                                                                                                                            |
 | _after-install-chroot_     | This stage happens after installing active and grub inside chroot[^1]                                                                                                                                                                                                               |
 | _after-install_            | This stage runs after active,passive and recovery images are installed and after disks have been encrypted                                                                                                                                                                          |

--- a/content/en/docs/Architecture/container.md
+++ b/content/en/docs/Architecture/container.md
@@ -11,7 +11,7 @@ A container-based operating system is an OS that is shipped via containers. Inde
 
 - **Single-image** The OS is a single container image which contains all the OS components, including Kernel and Initrd.
 - **Tamper-proof upgrades** Upgrades are atomic, A/B swaps with fallback mechanisms and automatic boot assessment.
-- **Distributed via container registries** Bootable images are standard OCI artifacts that can be hosted in any container regist
+- **Distributed via container registries** Bootable images are standard OCI artifacts that can be hosted in any container registry.
 - **Platform Engineer-friendly** Adapt the infrastructure to your needs by plugging images into your already-existing workflow pipeline. Customizing an immutable OS becomes as easy as writing a Dockerfile.
 
 ## A/B Upgrades
@@ -29,7 +29,7 @@ If you are operating a Kubernetes cluster and deploying applications on top, cha
 
 ![kairos-factory](https://user-images.githubusercontent.com/2420543/197808767-e213709d-af21-4e32-9a78-818f34170077.png)
 
-Container images can be extended after a build by using standard container building practices and seamlessly plug into your existing pipelines. Kairos allows to seamlessly upgrade to container images that are derived from other versions.
+Container images can be extended after a build by using standard container building practices and can seamlessly plug into your existing pipelines. Kairos allows you to seamlessly upgrade to container images that are derived from other versions.
 
 We believe that bringing rollbacks, or incremental patches upgrades increases the exposure to infrastructure drift. In opposition, immutable, single images are deployed to the nodes as they were apps - no more discrepancies in your nodes - no need of configuration management tools like Chef, Ansible, or alikes.
 

--- a/content/en/docs/Getting started/_index.md
+++ b/content/en/docs/Getting started/_index.md
@@ -30,7 +30,7 @@ Kairos comes in many flavors. These are the underlying Linux distributions on wh
 {{% /alert %}}
 
 1. Select your Kairos Flavor from the nav bar
-2. Click the following link to download an iso: {{<imageLink variant="standard" suffix=".iso">}}  
+2. Click the following link to download an iso: {{<imageLink variant="standard" suffix=".iso">}}
 
 ## Create a Virtual Machine (VM)
 
@@ -111,14 +111,6 @@ After logging in, you can check the status of the cluster with the `kubectl` too
 
 ```bash
 sudo -i
-```
-
-{{% alert title="Bug setting the KUBECONFIG automatically" color="warning" %}}
-There's a bug that affects all but openSUSE systems that prevents the KUBECONFIG to be set automatically. The fix has been merged and will be part of the v3.1.2 release. In the meantime just follow the steps below to set the KUBECONFIG manually.
-{{% /alert %}}
-
-```bash
-export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
 ```
 
 If you display the pods within the `kube-system` namespace, you should see the `coredns` and `local-path-provisioner` pods running. E.g.:


### PR DESCRIPTION
It looks like the `KUBECONFIG` env var is automatically exporting, so this alert is no longer necessary.