### PR TITLE
fix: add the correct cncf logo

### DIFF
--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -228,7 +228,7 @@
         <div class="join-us-wrap">
             {{ $cncf := resources.Get "/img/logo_cloudnative.png" }}
             <h2>We are a Cloud Native Computing Foundation sandbox project.</h2>
-            <img src="{{ $cncf.RelPermalink }}" alt="opened box" loading="lazy"/>
+            <img src="https://www.cncf.io/wp-content/uploads/2022/07/cncf-color-bg.svg" alt="opened box" loading="lazy"/>
             <p>The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see <a href="https://www.linuxfoundation.org/trademark-usage/" target="_blank">Trademark Usage</a>.</p>
         </div>
     </div>


### PR DESCRIPTION
FIXES: https://github.com/kairos-io/kairos/issues/2602
CLOSES: https://github.com/kairos-io/kairos/issues/2602

## Description
This PR fixes the old pixelated CNCF Logo to the official and the correct one.