### PR TITLE
Update single node example docs

### DIFF
--- a/content/en/docs/Getting started/configuration.md
+++ b/content/en/docs/Getting started/configuration.md
@@ -78,7 +78,7 @@ stages:
                 name: kairos
                 passwd: kairos
                 ssh_authorized_keys:
-                    - github:mauromorales
+                    - github:YOUR_GITHUB_USERNAME
 ```
 
 The name of the file is not important, but the extension and the location are. You must add your configuration files to `/oem/` and they must have a `.yaml` extension. Finally, the first line of the file must be `#cloud-config` to be recognized by the system.
@@ -113,7 +113,7 @@ stages:
                 name: kairos
                 passwd: kairos
                 ssh_authorized_keys:
-                    - github:mauromorales
+                    - github:YOUR_GITHUB_USERNAME
 ```
 
 Save the file and reboot the node. After the reboot, you should see the new hostname on the prompt.
@@ -142,7 +142,7 @@ stages:
                 name: kairos
                 passwd: kairos
                 ssh_authorized_keys:
-                    - github:mauromorales
+                    - github:YOUR_GITHUB_USERNAME
 ```
 
 {{% alert color="info" %}}


### PR DESCRIPTION
I think this change helps to keep the single node example concise and focused on the topic without explaining other details of the k3s configuration, those should probably go on a different page.

Additionally:

- adds a real-world example of a helm chart application that can be tested
- adds the admin group to the user creation