### PR TITLE
Add missing admin group to all configs

### DIFF
--- a/content/en/blog/home-lab-with-kairos-and-wireguard.md
+++ b/content/en/blog/home-lab-with-kairos-and-wireguard.md
@@ -155,7 +155,9 @@ If you prefer to not have the keys stored on your Kairos host filesystem, you ca
 
 users:
 - name: kairos
-passwd: kairos
+  passwd: kairos
+  groups:
+  - admin
 
 stages:
 after-install-chroot:

--- a/content/en/docs/Advanced/coco.md
+++ b/content/en/docs/Advanced/coco.md
@@ -41,6 +41,8 @@ k3s:
 users:
     - name: kairos
       passwd: kairos
+      groups:
+          - admin
 ```
 
 The bundle is making some changes on the host's filesystem (installs a customized containerd binary among other things) and a restart of the node is needed in order for the changes to be applied fully.

--- a/content/en/docs/Advanced/partition_encryption.md
+++ b/content/en/docs/Advanced/partition_encryption.md
@@ -102,6 +102,8 @@ users:
 - name: kairos
   # Change to your pass here
   passwd: kairos
+  groups:
+  - admin
   ssh_authorized_keys:
   # Replace with your github user and un-comment the line below:
   # - github:mudler
@@ -217,6 +219,8 @@ users:
 - name: kairos
   # Change to your pass here
   passwd: kairos
+  groups:
+  - admin
   ssh_authorized_keys:
   # Replace with your github user and un-comment the line below:
   # - github:mudler
@@ -280,6 +284,8 @@ users:
 - name: kairos
   # Change to your pass here
   passwd: kairos
+  groups:
+  - admin
   ssh_authorized_keys:
   # Replace with your github user and un-comment the line below:
   # - github:mudler

--- a/content/en/docs/Development/debugging-station.md
+++ b/content/en/docs/Development/debugging-station.md
@@ -112,6 +112,8 @@ hostname: debugging-station-{{ trunc 4 .MachineID }}
 users:
 - name: kairos
   passwd: kairos
+  groups:
+  - admin
   ssh_authorized_keys:
   - github:mudler
 
@@ -178,6 +180,8 @@ hostname: debugging-station-{{ trunc 4 .MachineID }}
 users:
 - name: kairos
   passwd: kairos
+  groups:
+  - admin
   ssh_authorized_keys:
   - github:mudler
 

--- a/content/en/docs/Examples/bundles.md
+++ b/content/en/docs/Examples/bundles.md
@@ -30,6 +30,8 @@ users:
 - name: kairos
   # Change to your pass here
   passwd: kairos
+  groups:
+  - admin
   ssh_authorized_keys:
   # Replace with your github user and un-comment the line below:
   # - github:mudler

--- a/content/en/docs/Examples/ha.md
+++ b/content/en/docs/Examples/ha.md
@@ -23,6 +23,8 @@ users:
 - name: kairos
   # Change to your pass here
   passwd: kairos
+  groups:
+  - admin
   #ssh_authorized_keys:
   ## Add your github user here!
   #- github:mudler
@@ -46,6 +48,8 @@ users:
 - name: kairos
   # Change to your pass here
   passwd: kairos
+  groups:
+  - admin
   ssh_authorized_keys:
   # Add your github user here!
   - github:mudler
@@ -74,6 +78,8 @@ users:
 - name: kairos
   # Change to your pass here
   passwd: kairos
+  groups:
+  - admin
   #ssh_authorized_keys:
   ## Add your github user here!
   #- github:mudler
@@ -99,6 +105,8 @@ users:
 - name: kairos
   # Change to your pass here
   passwd: kairos
+  groups:
+  - admin
   #ssh_authorized_keys:
   ## Add your github user here!
   #- github:mudler

--- a/content/en/docs/Examples/k3s-stages.md
+++ b/content/en/docs/Examples/k3s-stages.md
@@ -102,6 +102,8 @@ users:
 - name: kairos
   # Change to your pass here
   passwd: kairos
+  groups:
+  - admin
 
 stages:
   'provider-kairos.bootstrap.after.k3s-ready':

--- a/content/en/docs/Examples/localai.md
+++ b/content/en/docs/Examples/localai.md
@@ -27,6 +27,8 @@ hostname: localai-{{ trunc 4 .MachineID }}
 users:
 - name: kairos
   passwd: kairos
+  groups:
+  - admin
   ssh_authorized_keys:
     - github:mauromorales
 

--- a/content/en/docs/Examples/metallb.md
+++ b/content/en/docs/Examples/metallb.md
@@ -27,6 +27,8 @@ users:
 - name: kairos
   # Change to your pass here
   passwd: kairos
+  groups:
+  - admin
   ssh_authorized_keys:
   # Add your github user here!
   - github:mudler

--- a/content/en/docs/Examples/p2p_e2e.md
+++ b/content/en/docs/Examples/p2p_e2e.md
@@ -39,6 +39,8 @@ hostname: kairoslab-{{ trunc 4 .MachineID }}
 users:
 - name: kairos
   passwd: kairos
+  groups:
+  - admin
   ssh_authorized_keys:
   # Replace with your github user and un-comment the line below:
   - github:mudler
@@ -80,6 +82,8 @@ hostname: kairoslab-{{ trunc 4 .MachineID }}
 users:
 - name: kairos
   passwd: kairos
+  groups:
+  - admin
   ssh_authorized_keys:
   - github:mudler
   - github:mauromorales
@@ -120,6 +124,8 @@ hostname: kairoslab-{{ trunc 4 .MachineID }}
 users:
 - name: kairos
   passwd: kairos
+  groups:
+  - admin
   ssh_authorized_keys:
   - github:mudler
   - github:mauromorales

--- a/content/en/docs/Reference/auroraboot.md
+++ b/content/en/docs/Reference/auroraboot.md
@@ -466,6 +466,8 @@ users:
 - name: kairos
   # Change to your pass here
   passwd: kairos
+  groups:
+  - admin
   ssh_authorized_keys:
   # Replace with your github user and un-comment the line below:
   - github:mudler

--- a/content/en/docs/Reference/build_raw_images_with_qemu.md
+++ b/content/en/docs/Reference/build_raw_images_with_qemu.md
@@ -41,6 +41,8 @@ install:
 users:
 - name: "kairos"
   passwd: kairos
+  groups:
+  - admin
   #lock_passwd: true
   #ssh_authorized_keys:
   #- github:mudler

--- a/content/en/docs/Reference/reset.md
+++ b/content/en/docs/Reference/reset.md
@@ -80,6 +80,8 @@ stringData:
     users:
     - name: kairos
       passwd: kairos
+      groups:
+      - admin
       ssh_authorized_keys:
       - github:mudler
   add-config-file.sh: |
@@ -145,6 +147,8 @@ stringData:
     users:
     - name: kairos
       passwd: kairos
+      groups:
+      - admin
       ssh_authorized_keys:
       - github:mudler
   add-config-file.sh: |

--- a/content/en/docs/Upgrade/kubernetes.md
+++ b/content/en/docs/Upgrade/kubernetes.md
@@ -131,6 +131,8 @@ bundles:
 users:
 - name: kairos
   passwd: kairos
+  groups:
+  - admin
 
 k3s:
  enabled: true


### PR DESCRIPTION
latest version already has this as a requirement but docs don't reflect so. This and the last few commits on master should be ported to v3.3.1