### PR TITLE
Add alert where k0s cannot be used

### DIFF
--- a/content/en/docs/Examples/airgap.md
+++ b/content/en/docs/Examples/airgap.md
@@ -1,7 +1,6 @@
 ---
 title: "How to Create an Airgap K3s Installation with Kairos"
-linkTitle: "Airgapped ISO with AuroraBoot"
-weight: 4
+linkTitle: "Airgapped ISO"
 description: This section describe examples on how to use AuroraBoot and Kairos bundles to create ISOs for airgapped installs
 ---
 

--- a/content/en/docs/Examples/bundles.md
+++ b/content/en/docs/Examples/bundles.md
@@ -1,7 +1,6 @@
 ---
 title: "Bundles"
 linkTitle: "Bundles"
-weight: 4
 description: This section describe examples on how to use a Kairos bundle to deploy MetalLB on top of K3s
 ---
 

--- a/content/en/docs/Examples/core.md
+++ b/content/en/docs/Examples/core.md
@@ -1,7 +1,6 @@
 ---
 title: "Using Kairos Core Images as an Installer"
 linkTitle: "Using Kairos Core Images as an Installer"
-weight: 4
 description: Core images serve as the foundation for creating downstream images or as an installer for deploying other images during the installation process. In this guide, we'll take a closer look at using Kairos core images as an installer to deploy other container images.
 ---
 

--- a/content/en/docs/Examples/ha.md
+++ b/content/en/docs/Examples/ha.md
@@ -1,7 +1,6 @@
 ---
 title: "High Availability K3s deployments"
 linkTitle: "HA with K3s"
-weight: 3
 description: This section contains instructions how to deploy Kairos with a High Available control-plane for K3s 
 ---
 

--- a/content/en/docs/Examples/k3s-stages.md
+++ b/content/en/docs/Examples/k3s-stages.md
@@ -1,7 +1,6 @@
 ---
 title: "Run stages along with K3s"
 linkTitle: "Run stages along with K3s"
-weight: 4
 description: This section describes a method to run stages with k3s.
 ---
 

--- a/content/en/docs/Examples/kdump.md
+++ b/content/en/docs/Examples/kdump.md
@@ -1,7 +1,6 @@
 ---
 title: "Enabling kdump"
 linkTitle: "Enabling kdump"
-weight: 4
 description: This section describe examples on how to enable kdump in Kairos derivatives
 ---
 

--- a/content/en/docs/Examples/keylime.md
+++ b/content/en/docs/Examples/keylime.md
@@ -1,7 +1,6 @@
 ---
 title: "Keylime agent"
 linkTitle: "Keylime agent"
-weight: 4
 description: This section describes an example on how to create a custom derivative with the Keylime agent
 ---
 

--- a/content/en/docs/Examples/localai.md
+++ b/content/en/docs/Examples/localai.md
@@ -1,7 +1,6 @@
 ---
 title: "LocalAI"
 linkTitle: "LocalAI"
-weight: 4
 description: This section describe examples on how to deploy Kairos with k3s and LocalAI
 ---
 

--- a/content/en/docs/Examples/metallb.md
+++ b/content/en/docs/Examples/metallb.md
@@ -1,7 +1,6 @@
 ---
 title: "MetalLB"
 linkTitle: "MetalLB"
-weight: 4
 description: This section describe examples on how to deploy Kairos with k3s and MetalLB
 ---
 

--- a/content/en/docs/Examples/multi-node-p2p-ha-kubevip.md
+++ b/content/en/docs/Examples/multi-node-p2p-ha-kubevip.md
@@ -1,16 +1,12 @@
 ---
 title: "Deploying a High-Availability K3s Cluster with KubeVIP"
-linkTitle: "Deploying a High-Availability K3s Cluster with KubeVIP"
-weight: 6
-date: 2022-11-13
+linkTitle: "P2P multi-node cluster HA with KubeVIP"
 description: This guide walks through the process of deploying a highly-available, P2P self-coordinated k3s cluster with KubeVIP, which provides a high available Elastic IP for the control plane. 
 ---
 
-{{% alert title="Warning" color="warning" %}}
-
-This feature is experimental. Run in production servers at your own risk.
+{{% alert title="Network" color="warning" %}}
+This feature is experimental and has only been tested on local setups. Run in production servers at your own risk.
 Feedback and bug reports are welcome, as we are improving the p2p aspects of Kairos.
-
 {{% /alert %}}
 
 K3s is a lightweight Kubernetes distribution that is easy to install and operate. It's a great choice for small and edge deployments, but it can also be used to create a high-availability (HA) cluster with the help of [KubeVIP](https://kube-vip.io/). In this guide, we'll walk through the process of deploying a highly-available k3s cluster with KubeVIP, which provides a high available ip for the control plane.

--- a/content/en/docs/Examples/multi-node-p2p-ha.md
+++ b/content/en/docs/Examples/multi-node-p2p-ha.md
@@ -1,16 +1,16 @@
 ---
-title: "Configuring Automatic High Availability in Kairos"
-linkTitle: "Configuring Automatic High Availability in Kairos"
-weight: 6
-date: 2022-11-13
+title: "P2P Multi-Node Cluster with High Availability"
+linkTitle: "P2P multi-node cluster HA"
 description: Kairos makes it easy to configure automatic High Availability (HA) in your cluster by using cloud-config. With just a few simple steps, you can have a fully-functioning HA setup in your cluster.
 ---
 
-{{% alert title="Warning" color="warning" %}}
-
-This feature is experimental. Run in production servers at your own risk.
+{{% alert title="Network" color="warning" %}}
+This feature is experimental and has only been tested on local setups. Run in production servers at your own risk.
 Feedback and bug reports are welcome, as we are improving the p2p aspects of Kairos.
+{{% /alert %}}
 
+{{% alert title="K8s Distribution" color="warning" %}}
+This feature is only working with the k3s distribution.
 {{% /alert %}}
 
 To enable automatic HA rollout, enable the `p2p.auto.ha.enable` option in your cloud-config, and set up a number of `master_nodes`. The number of `master_nodes` is the number of additional masters in addition to the initial HA role. There will always be a minimum of 1 master, which is already taken into account. For example, setting up `master_nodes` to two will result in a total of 3 master nodes in your cluster.

--- a/content/en/docs/Examples/multi-node-p2p.md
+++ b/content/en/docs/Examples/multi-node-p2p.md
@@ -1,16 +1,12 @@
 ---
 title: "P2P multi-node cluster"
 linkTitle: "P2P multi-node cluster"
-weight: 6
-date: 2022-11-13
 description: Install Kairos with p2p support, on a multi-node cluster
 ---
 
-{{% alert title="Warning" color="warning" %}}
-
-This feature is experimental. Run in production servers at your own risk.
+{{% alert title="Network" color="warning" %}}
+This feature is experimental and has only been tested on local setups. Run in production servers at your own risk.
 Feedback and bug reports are welcome, as we are improving the p2p aspects of Kairos.
-
 {{% /alert %}}
 
 A multi-node scenario with non-HA is the default peer-to-peer (P2P) configuration in Kairos. To set this up, you will need to configure the `network_token` under the `p2p` configuration in your cloud-config file. Once you have set this, Kairos will handle the configuration of each node.

--- a/content/en/docs/Examples/multi-node.md
+++ b/content/en/docs/Examples/multi-node.md
@@ -1,7 +1,6 @@
 ---
 title: "Multi-Node Cluster"
 linkTitle: "Multi-node cluster"
-weight: 1
 description: This section describe examples on how to deploy Kairos as a multi-node cluster
 ---
 

--- a/content/en/docs/Examples/openamt.md
+++ b/content/en/docs/Examples/openamt.md
@@ -1,8 +1,6 @@
 ---
 title: "Intel Open AMT Registration"
 linkTitle: "Intel Open AMT Registration"
-weight: 6
-date: 2023-04-17
 description: This bundle configures Intel AMT devices during Kairos installation.
 ---
 

--- a/content/en/docs/Examples/p2p_e2e.md
+++ b/content/en/docs/Examples/p2p_e2e.md
@@ -1,25 +1,17 @@
 ---
-title: "P2P multi-node cluster with AuroraBoot"
-linkTitle: "P2P multi-node cluster with AuroraBoot"
-weight: 6
-date: 2023-02-15
+title: "P2P Multi-Node Cluster Provisioned via Netboot"
+linkTitle: "P2P multi-node cluster netboot"
 description: Full end to end example to bootstrap a self-coordinated cluster with Kairos and AuroraBoot
 ---
 
-{{% alert title="Note" color="success" %}}
-
-This feature is experimental. Run in production servers at your own risk.
+{{% alert title="Network" color="warning" %}}
+This feature is experimental and has only been tested on local setups. Run in production servers at your own risk.
 Feedback and bug reports are welcome, as we are improving the p2p aspects of Kairos.
-
 {{% /alert %}}
 
 Deploying Kubernetes at the Edge can be a complex and time-consuming process, especially when it comes to setting up and managing multiple clusters. To make this process easier, Kairos leverages peer-to-peer technology to automatically coordinate and create Kubernetes clusters without the need of a control management interface.
 
 To leverage p2p self-coordination capabilities of Kairos, you will need to configure the `network_token` under the `p2p` configuration block in your cloud-config file. Once you have set this, Kairos will handle the configuration of each node.
-
-{{% alert title="Note" color="success" %}}
-You can see this example live in the [Kairos and libp2p video]({{< relref "Media#how-kairos-uses-libp2p" >}} "Media") in the [Media Section]({{< relref "Media" >}} "Media")
-{{% /alert %}}
 
 ## Description
 

--- a/content/en/docs/Examples/single-node-p2p.md
+++ b/content/en/docs/Examples/single-node-p2p.md
@@ -1,16 +1,12 @@
 ---
 title: "P2P single-node cluster"
 linkTitle: "P2P single-node cluster"
-weight: 6
-date: 2022-11-13
 description: This documentation page provides instructions on how to install Kairos with P2P support on a single-node cluster
 ---
 
-{{% alert title="Warning" color="warning" %}}
-
-This feature is experimental. Run in production servers at your own risk.
+{{% alert title="Network" color="warning" %}}
+This feature is experimental and has only been tested on local setups. Run in production servers at your own risk.
 Feedback and bug reports are welcome, as we are improving the p2p aspects of Kairos.
-
 {{% /alert %}}
 
 Installing Kairos with P2P support on a single-node cluster requires a few specific steps. To begin, it's important to note that in a single-node scenario, the role must be enforced to a specific role. In a non-HA (high availability) setup, that role can be either `master` or `worker`. In a single-node cluster, there will be only one master node that needs to be configured explicitly.

--- a/content/en/docs/Examples/single-node.md
+++ b/content/en/docs/Examples/single-node.md
@@ -1,7 +1,6 @@
 ---
 title: "Single-Node cluster"
 linkTitle: "Single-node cluster"
-weight: 1
 description: This section describe examples on how to deploy Kairos single-node cluster
 ---
 

--- a/content/en/docs/Examples/virtual-box.md
+++ b/content/en/docs/Examples/virtual-box.md
@@ -1,7 +1,6 @@
 ---
-title: "Kairos Trusted Boot in Virtual Box"
-linkTitle: "Kairos Trusted Boot in Virtual Box"
-weight: 1
+title: "Kairos' Trusted Boot in Virtual Box"
+linkTitle: "Trusted Boot in Virtual Box"
 description: This section describes how to use Virtual Box to boot Kairos in "Trusted boot" mode
 ---
 

--- a/content/en/docs/Examples/wifi.md
+++ b/content/en/docs/Examples/wifi.md
@@ -1,7 +1,6 @@
 ---
-title: "Configuring wifi via cloud-config"
-linkTitle: "Configuring wifi via cloud-config"
-weight: 1
+title: "Configuring WiFi via Cloud-Config"
+linkTitle: "WiFi"
 description: This section describe examples on how to deploy Kairos with WiFi
 ---
 

--- a/content/en/docs/Installation/p2p.md
+++ b/content/en/docs/Installation/p2p.md
@@ -6,11 +6,9 @@ date: 2022-11-13
 description: Install Kairos with p2p support
 ---
 
-{{% alert title="Note" color="success" %}}
-
-This feature is experimental. Run in production servers at your own risk.
+{{% alert title="Network" color="warning" %}}
+This feature is experimental and has only been tested on local setups. Run in production servers at your own risk.
 Feedback and bug reports are welcome, as we are improving the p2p aspects of Kairos.
-
 {{% /alert %}}
 
 Deploying Kubernetes at the Edge can be a complex and time-consuming process, especially when it comes to setting up and managing multiple clusters. To make this process easier, Kairos leverages peer-to-peer technology to automatically coordinate and create Kubernetes clusters without the need of a control management interface.

--- a/content/en/docs/Media/_index.md
+++ b/content/en/docs/Media/_index.md
@@ -28,9 +28,6 @@ description: Presentation Slides, Videos and other media on Kairos
 
 {{< youtube id="XD5nfMf59v4" title="How we build and maintain Kairos" >}}
 
-### How Kairos uses libp2p
-
-{{< youtube id="7Vym18wz9Uw" title="Kairos and libp2p" >}}
 
 ### CNCF TAG-Runtime Meeting 09-14-2023 (Kairos) 
 

--- a/content/en/docs/Reference/entangle.md
+++ b/content/en/docs/Reference/entangle.md
@@ -7,11 +7,9 @@ description: Inter-connecting Kubernetes clusters without the need of exposing a
  
 ---
 
-{{% alert title="Note" color="warning" %}}
-
-This feature is experimental. Run in production servers at your own risk.
+{{% alert title="Network" color="warning" %}}
+This feature is experimental and has only been tested on local setups. Run in production servers at your own risk.
 Feedback and bug reports are welcome, as we are improving the p2p aspects of Kairos.
-
 {{% /alert %}}
 
 Kairos has two Kubernetes Native extensions ( [entangle](https://github.com/kairos-io/entangle) and [entangle-proxy](https://github.com/kairos-io/entangle-proxy) ) that allows to interconnect services between different clusters via P2P with a shared secret.


### PR DESCRIPTION
All other example explicitly say it's for k3s or for both.

Also changes the order of the examples so it's in alphabetical order