### PR TITLE
Add llmstxt

### DIFF
--- a/assets/llms.go.txt
+++ b/assets/llms.go.txt
@@ -1,0 +1,46 @@
+{{ with .Site.Title -}}
+# {{ . }}
+{{- end }}
+
+{{ with .Site.Params.Description -}}
+> {{ . }}
+{{- end }}
+
+{{ range (where (sort ((.Site.GetPage "/").Pages) "Weight" "asc" "Date" "desc" "Lastmod" "desc") "Params.sitemap_exclude" "ne" true) -}}
+    - [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
+{{ end -}}
+
+{{/* Sections */}}
+{{ range (where (sort ((.Site.GetPage "/").Sections) "Weight" "asc" "Date" "desc" "Lastmod" "desc") "Params.sitemap_exclude" "ne" true) -}}
+{{ with .Title -}}
+## {{ . }}
+{{- end }}
+
+{{ with .Description -}}
+> {{ . }}
+{{- end }}
+
+{{ range (where (sort .Pages "Weight" "asc" "Date" "desc" "Lastmod" "desc") "Params.sitemap_exclude" "ne" true) -}}
+    {{ if .Title -}}
+        - [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
+    {{- end }}
+{{ end -}}
+
+{{/* Sub-Sections */}}
+{{ range (where (sort .Sections "Weight" "asc" "Date" "desc" "Lastmod" "desc") "Params.sitemap_exclude" "ne" true) -}}
+{{ with .Title -}}
+### {{ . }}
+{{- end }}
+
+{{ with .Description -}}
+> {{ . }}
+{{- end }}
+
+{{ range (where (sort .Pages "Weight" "asc" "Date" "desc" "Lastmod" "desc") "Params.sitemap_exclude" "ne" true) -}}
+    {{ if .Title -}}
+        - [{{ .Title }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
+    {{- end }}
+{{ end }}
+{{ end -}}
+
+{{ end -}} 

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -1,4 +1,5 @@
 ---
 title: Blog
 menu: {main: {weight: 50}}
+sitemap_exclude: true
 ---

--- a/content/en/commercial-support.md
+++ b/content/en/commercial-support.md
@@ -2,6 +2,7 @@
 title: "Announcing Commercial Support"
 date: 2024-10-23T12:53:13+01:00
 author: Mauro Morales ([Twitter](https://twitter.com/mauromrls)) ([GitHub](https://github.com/mauromorales))
+sitemap_exclude: true
 ---
 
 # New Options for Enhanced Reliability and Peace of Mind

--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -3,4 +3,5 @@ title: Community
 menu:
   main:
     weight: 40
+sitemap_exclude: true
 ---

--- a/content/en/docs/Advanced/_index.md
+++ b/content/en/docs/Advanced/_index.md
@@ -4,6 +4,6 @@ linkTitle: "Advanced"
 icon: fa-regular fa-gear
 weight: 5
 description: |
-    In this section we will show you advanced configurations for your Kairos system.
+    Learn how to configure advanced Kairos features such as system extensions, partitions, bundles, and confidential computing.
 ---
 

--- a/content/en/docs/Advanced/build.md
+++ b/content/en/docs/Advanced/build.md
@@ -12,7 +12,7 @@ The feature is experimental and API is likely going to be subject to changes, do
 {{% /alert %}}
 
 {{% alert title="Note" color="info" %}}
-This guide provides detailed information about building Kairos images. For a complete guide on creating custom cloud images, including when and how to use these build methods, see [Creating Custom Cloud Images]({{< ref "/docs/advanced/creating_custom_cloud_images" >}}).
+This guide provides detailed information about building Kairos images. For a complete guide on creating custom cloud images, including when and how to use these build methods, see [Creating Custom Cloud Images]({{< ref "creating_custom_cloud_images.md" >}}).
 {{% /alert %}}
 
 This documentation section describes how the Kairos Kubernetes Native API extensions can be used to build custom appliances or booting medium for Kairos.

--- a/content/en/docs/Advanced/customizing.md
+++ b/content/en/docs/Advanced/customizing.md
@@ -6,7 +6,7 @@ description: Learn how to customize Kairos images to suit your needs
 ---
 
 {{% alert title="Note" color="info" %}}
-This guide focuses on customizing Kairos images. For a complete guide on creating custom cloud images from scratch, including when and how to apply these customizations, see [Creating Custom Cloud Images]({{< ref "/docs/advanced/creating_custom_cloud_images" >}}).
+This guide focuses on customizing Kairos images. For a complete guide on creating custom cloud images from scratch, including when and how to apply these customizations, see [Creating Custom Cloud Images]({{< ref "creating_custom_cloud_images.md" >}}).
 {{% /alert %}}
 
 Kairos is an open source, container-based operating system. To modify Kairos and add a package, you'll need to build a container image from the [Kairos images]({{< relref "../reference/image_matrix" >}}). Here's an example with Docker which adds `figlet`:

--- a/content/en/docs/Announcements/_index.md
+++ b/content/en/docs/Announcements/_index.md
@@ -4,6 +4,7 @@ linkTitle: "Announcements"
 icon: fa-solid fa-bullhorn
 weight: 2
 description: "A single stop to learn about Known Issues, Deprecation Warnings and/or Remarkable Changes in this release"
+sitemap_exclude: true
 ---
 
 {{% alert title="Enki" color="warning" %}}

--- a/content/en/docs/Architecture/container.md
+++ b/content/en/docs/Architecture/container.md
@@ -1,6 +1,7 @@
 ---
 title: "Container based"
 linkTitle: "Container"
+description: Discover how Kairos delivers its entire OS as a container image, enabling predictable upgrades and simple version control.
 weight: 2
 date: 2022-11-13
 ---

--- a/content/en/docs/Architecture/immutable.md
+++ b/content/en/docs/Architecture/immutable.md
@@ -1,6 +1,7 @@
 ---
 title: "Immutable"
 linkTitle: "Immutable"
+description: "Learn about Kairos' immutable architecture design, where the system boots in a restricted, permissionless mode with read-only paths. Discover how this approach enhances security, simplifies maintenance, and enables predictable upgrades across your infrastructure."
 weight: 1
 date: 2022-11-13
 ---
@@ -55,9 +56,9 @@ Kairos after installation will create the following partitions:
 
 The persistent partition is mounted during boot on `/usr/local`, and additional paths are mount-bind to it. Those configuration aspects are defined in a [cloud-config](https://github.com/kairos-io/packages/blob/9b49d6aacd554cd990c87b63de1221328bbcdb81/packages/static/kairos-overlay-files/files/system/oem/00_rootfs.yaml#L18) file. It is possible to override such configuration, via a custom cloud-config, during installation.
 
-The Recovery system allows to perform emergency tasks, in case of failure from the active and passive images. Furthermore a fallback mechanism will take place, so that in case of failures the booting sequence will be as follows: “A -> B -> Recovery”.
+The Recovery system allows to perform emergency tasks, in case of failure from the active and passive images. Furthermore a fallback mechanism will take place, so that in case of failures the booting sequence will be as follows: "A -> B -> Recovery".
 
-The upgrade happens in a transition image and takes place only after all the necessary steps are completed. An upgrade of the ‘A/B’ partitions can be done [with Kubernetes](/docs/upgrade/kubernetes) or [manually](/docs/upgrade/manual). The upgrade will create a new pristine image, that will be selected as active for the next reboot, the old one will be flagged as passive. If we are performing the same from the passive system, only the active is subject to changes.
+The upgrade happens in a transition image and takes place only after all the necessary steps are completed. An upgrade of the 'A/B' partitions can be done [with Kubernetes](/docs/upgrade/kubernetes) or [manually](/docs/upgrade/manual). The upgrade will create a new pristine image, that will be selected as active for the next reboot, the old one will be flagged as passive. If we are performing the same from the passive system, only the active is subject to changes.
 
 ### Kernel and Initrd
 

--- a/content/en/docs/Architecture/secureboot.md
+++ b/content/en/docs/Architecture/secureboot.md
@@ -1,6 +1,7 @@
 ---
 title: "SecureBoot support"
 linkTitle: "SecureBoot support"
+description: Learn how Kairos supports Secure Boot using signed artifacts to ensure system integrity across distributions.
 weight: 3
 date: 2024-01-29
 ---

--- a/content/en/docs/Architecture/trustedboot.md
+++ b/content/en/docs/Architecture/trustedboot.md
@@ -10,7 +10,7 @@ Trusted boot is an architectural requirement of [SENA (Secure Edge Native Archit
 
 > You can read more about Trusted Boot in https://0pointer.de/blog/brave-new-trusted-boot-world.html and about SENA here: https://kairos.io/blog/2023/04/18/kairos-is-now-part-of-the-secure-edge-native-architecture-by-spectro-cloud-and-intel/
 
-By combining Secure Boot, Measured Boot and FDE we can guarantee that a system was not tampered with, and the user-data is protected by cold attacks, we refer to this combination of technologies stacked together with “Trusted Boot” or “Trusted Boot Experience”. 
+By combining Secure Boot, Measured Boot and FDE we can guarantee that a system was not tampered with, and the user-data is protected by cold attacks, we refer to this combination of technologies stacked together with "Trusted Boot" or "Trusted Boot Experience". 
 
 *FDE* stands for Full Disk Encryption. It is a security measure that encrypts the entire contents of a disk drive, including the operating system, system files, and user data. The purpose of FDE is to protect data stored on the disk from unauthorized access in the event of theft or loss of the device.
 
@@ -23,7 +23,7 @@ By combining Secure Boot, Measured Boot and FDE we can guarantee that a system w
 
 [UKI](https://uapi-group.org/specifications/specs/unified_kernel_image/) is a specific file format tailored to achieve a tamper-proof system and encryption of user-data bound to the silicon by relying on HW capabilities. 
 
-> UKI stands for “Unified Kernel Images”. UKI files are a single, fat binary that encompasses the OS and the needed bits in order to boot the full system with a single, verified file. You can read technical details here: [Brave New Trusted Boot World](https://0pointer.de/blog/brave-new-trusted-boot-world.html).
+> UKI stands for "Unified Kernel Images". UKI files are a single, fat binary that encompasses the OS and the needed bits in order to boot the full system with a single, verified file. You can read technical details here: [Brave New Trusted Boot World](https://0pointer.de/blog/brave-new-trusted-boot-world.html).
 
 Trusted Boot in Kairos works by generating UKI images from container images. The UKI file is a single, fat binary that encompasses the OS and the needed bits in order to boot the full system with a single, verified file. This file can be used for upgrades and used as usual in the lifecycle of the Kairos node.
 
@@ -39,7 +39,7 @@ The UKI files are generated from container images as usual.
 
 ![Trusted boot](https://github.com/kairos-io/kairos-docs/assets/2420543/2f49d592-9ae3-43ee-b22b-0313be455bf7)
 
-The process to generate the installable medium is described in the [Trustedboot installation documentation]({{%relref "/docs/installation/trustedboot" %}}). Internally we rely on the *osbuilder* tool to generate all the installation artifacts from a single container image.
+The process to generate the installable medium is described in the [Trustedboot installation documentation]({{< ref "trustedboot.md" >}}). Internally we rely on the *osbuilder* tool to generate all the installation artifacts from a single container image.
 
 ### Booting process
 
@@ -50,15 +50,15 @@ The booting process of an installed system with Trusted Boot is different from a
 1. The Firmware loads the `systemd-boot` bootloader from the EFI partition
 2. `systemd-boot` loads the UKI file from the EFI partition (that can be either the Active system, the passive or recovery system)
 3. The EFI system starts. The kernel and the initrd are loaded from the UKI file, and the kernel is booted with the command line specified in the UKI file. 
-4. The initrd will decrypt the user-data and mount the portions of it in the root filesystem. This includes for instance any changes to `/etc` (like adding new users and passwords), `/usr/local`, and all the mount bindpoints specified in the configuration file (see [Bind mount d ocumentation]({{%relref "/docs/advanced/customizing#bind-mounts" %}}) ). There is no second stage loaded and no system pivoting, the system is booted directly from the UKI file.
+4. The initrd will decrypt the user-data and mount the portions of it in the root filesystem. This includes for instance any changes to `/etc` (like adding new users and passwords), `/usr/local`, and all the mount bindpoints specified in the configuration file (see [Bind mount documentation]({{< ref "customizing.md#bind-mounts" >}}) ). There is no second stage loaded and no system pivoting, the system is booted directly from the UKI file.
 
 ### Booting system
 
 ![Trusted boot](https://github.com/kairos-io/kairos-docs/assets/2420543/757870d3-3b40-46ea-9c86-13c4a545f167)
 
-There is no difference with a layout of a standard Kairos system (as explained in the [Immutable OS]({{%relref "/docs/architecture/immutable" %}}) page), however in this setup now the partitions containing data are always encrypted:
+There is no difference with a layout of a standard Kairos system (as explained in the [Immutable OS]({{< ref "immutable.md" >}}) page), however in this setup now the partitions containing data are always encrypted:
 
-- [List of persistent data path overlayed and encrypted](https://github.com/kairos-io/packages/blob/528682cddf7191fb52580e7c41a33e73c1ee0001/packages/static/kairos-overlay-files/files/system/oem/00_rootfs_uki.yaml#L18) (see also [the bind mount documentation]({{%relref "/docs/advanced/customizing#bind-mounts" %}}) to customize it with your own paths).
+- [List of persistent data path overlayed and encrypted](https://github.com/kairos-io/packages/blob/528682cddf7191fb52580e7c41a33e73c1ee0001/packages/static/kairos-overlay-files/files/system/oem/00_rootfs_uki.yaml#L18) (see also [the bind mount documentation]({{< ref "customizing.md#bind-mounts" >}}) to customize it with your own paths).
 - `/oem` encrypted
 - `/usr/local` encrypted
 - `/etc` ephemeral
@@ -76,11 +76,11 @@ The keys are used to sign the UKI file, and to generate a PCR policy keypair req
 
 ### Expanding the system with system extensions
 
-Check the relevant documentation on how to [extend the system with system extensions]({{%relref "/docs/advanced/sys-extensions" %}})
+Check the relevant documentation on how to [extend the system with system extensions]({{< ref "sys-extensions.md" >}})
 
 ### Trusted Boot - Boot Assessment
 
-See the [Trusted Boot - Boot Assessment]({{%relref "/docs/examples/boot_assessment_trusted_boot" %}}) documentation for more information on how to enable automatic boot assessment with Trusted Boot and how to make your own services participate in the boot assessment process.
+See the [Trusted Boot - Boot Assessment]({{< ref "boot_assessment_trusted_boot.md" >}}) documentation for more information on how to enable automatic boot assessment with Trusted Boot and how to make your own services participate in the boot assessment process.
 
 ### Considerations
 
@@ -97,3 +97,13 @@ UKI file's signatures are including also the kernel command line, so any change 
 - [SUPPORT OF SECURE BOOT IN SYSTEMD-BOOT PROJECT](https://www.vut.cz/www_base/zav_prace_soubor_verejne.php?file_id=132208)
 - [UKI file format](https://uapi-group.org/specifications/specs/unified_kernel_image/#file-format)
 - [Secure Boot](https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot)
+
+For more information about installing Kairos with Trusted Boot, see the [Trusted Boot Installation Guide]({{< ref "trustedboot.md" >}}).
+
+For more information about customizing Kairos images, see the [Customizing Images]({{< ref "customizing.md" >}}) guide.
+
+For more information about the immutable nature of Kairos, see the [Immutable Architecture]({{< ref "immutable.md" >}}) guide.
+
+For more information about system extensions, see the [System Extensions]({{< ref "sys-extensions.md" >}}) guide.
+
+For a complete example of boot assessment with Trusted Boot, see the [Boot Assessment with Trusted Boot]({{< ref "boot_assessment_trusted_boot.md" >}}) guide.

--- a/content/en/docs/Development/development.md
+++ b/content/en/docs/Development/development.md
@@ -3,7 +3,7 @@ title: "Development notes"
 linkTitle: "Development"
 weight: 1
 date: 2022-11-13
-description: Guidelines when developing Kairos
+description: Learn how to contribute to Kairos by exploring its development practices, debugging tools, and supported hardware.
 ---
 
 Here you can find development notes intended for maintainers and guidance for new contributors.

--- a/content/en/docs/Examples/_index.md
+++ b/content/en/docs/Examples/_index.md
@@ -4,7 +4,7 @@ linkTitle: "Examples"
 icon: fa-regular fa-file
 weight: 5
 description: |
-    Here, you will find a variety of examples that demonstrate how to use Kairos to create and manage Kubernetes clusters on bare metal.
+    Explore hands-on examples that show how to deploy Kairos clusters using K3s, bundles, VPNs, airgapped environments, and more.
 ---
 
 ## Troubleshooting

--- a/content/en/docs/Examples/boot_assessment_trusted_boot.md
+++ b/content/en/docs/Examples/boot_assessment_trusted_boot.md
@@ -140,7 +140,7 @@ While the above configurations are independent, combining them can create a robu
 
 ## Using cloud configs to automate the process
 
-As usual you can use [cloud-init]({{%relref "/docs/architecture/cloud-init" %}}) with the different [stages]({{%relref "/docs/reference/stage_modules" %}}) to automate this process. Here is an example of how to use cloud-init to enable boot assessment and configure services to participate in the boot assessment process:
+As usual you can use {{< ref "cloud-init.md" >}} with the different {{< ref "stage_modules.md" >}}) to automate this process. Here is an example of how to use cloud-init to enable boot assessment and configure services to participate in the boot assessment process:
 
 ```yaml
 #cloud-config
@@ -178,7 +178,7 @@ stages:
  - We recommend using this feature with caution, as it can lead to a boot loop if not configured correctly.
  - Ideally, as the upgrade is done against the active images, we would recommend having 2 service overrides, one for the active and one for the passive, to avoid the system rebooting on passive boot entries and having a safe fallback to the active boot entry. This can be achieved by using and IF stanza when using cloud-init to check for the system state (marked by the files `/run/cos/active_mode` and `/run/cos/passive_mode`) so the service that auto reboots can be started only on the active boot entry.
 
-The follow up example uses [cloud-init]({{%relref "/docs/architecture/cloud-init" %}}) to generate 2 different service overrides during initramfs, one for the active and one for the passive boot entry. Only when selecting the active entry will the service auto restart:
+The follow up example uses {{< ref "cloud-init.md" >}} to generate 2 different service overrides during initramfs, one for the active and one for the passive boot entry. Only when selecting the active entry will the service auto restart:
 
 ```yaml
 #cloud-config
@@ -224,4 +224,7 @@ stages:
          enabled:
             - <service-name>
 ```
+   
+For more information about cloud-init in Kairos, see the [Cloud-Init Architecture]({{< ref "cloud-init.md" >}}) guide.
+For more information about stage modules, see the [Stage Modules Reference]({{< ref "stage_modules.md" >}}).
    

--- a/content/en/docs/Examples/k3s-stages.md
+++ b/content/en/docs/Examples/k3s-stages.md
@@ -26,7 +26,7 @@ Some use cases require a stage to run after the K3s servers are up, such as appl
 
 ### Building the custom derivative
 
-We will keep this short as there are more docs that go more in-depth into building your derivatives than this tutorial such as the [Customizing page]({{%relref "/docs/advanced/customizing" %}}).
+We will keep this short as there are more docs that go more in-depth into building your derivatives than this tutorial such as the [Customizing page]({{< ref "customizing.md" >}}).
 
 The main step is to create an image that has the systemd units we need to run our stages.
 
@@ -77,7 +77,7 @@ $ docker build -t k3s-stage-kairos .
 
 ### Build an iso from that artifact
 
-Again, this tutorial does not cover this part deeply as there already are docs that provide a deep insight into custom images such as the the [AuroraBoot page]({{%relref "/docs/reference/auroraboot" %}}).
+Again, this tutorial does not cover this part deeply as there already are docs that provide a deep insight into custom images such as the the [AuroraBoot page]({{< ref "auroraboot.md" >}}).
 
 ```bash
 $ docker run -v "$PWD"/build-iso:/tmp/auroraboot -v /var/run/docker.sock:/var/run/docker.sock --rm -ti quay.io/kairos/auroraboot --set container_image="docker://k3s-stage-kairos" --set "disable_http_server=true" --set "disable_netboot=true" --set "state_dir=/tmp/auroraboot"

--- a/content/en/docs/Examples/kdump.md
+++ b/content/en/docs/Examples/kdump.md
@@ -32,7 +32,7 @@ This is why we need a clean initramfs that disables most of the modules and moun
 
 ### Building the custom derivative
 
-We will keep this short as there is more docs about building your own derivatives than what we can go in this tutorial like the [Customizing page]({{%relref "/docs/advanced/customizing" %}})
+We will keep this short as there is more docs about building your own derivatives than what we can go in this tutorial like the [Customizing page]({{< ref "customizing.md" >}})
 
 The main step is to build a clean initrd that has the kdump module and can mount persistent to store the kernel dump.
 
@@ -84,7 +84,7 @@ $ docker build -t kdump-kairos .
 
 ### Build an iso from that artifact
 
-Again, this tutorial does not cover this part deeply as there are docs providing a deep insight onto this like the [AuroraBoot page]({{%relref "/docs/reference/auroraboot" %}})
+Again, this tutorial does not cover this part deeply as there are docs providing a deep insight onto this like the [AuroraBoot page]({{< ref "auroraboot.md" >}})
 
 ```bash
 $ docker run -v "$PWD"/build-iso:/tmp/auroraboot -v /var/run/docker.sock:/var/run/docker.sock --rm -ti quay.io/kairos/auroraboot --set container_image="docker://kdump-kairos" --set "disable_http_server=true" --set "disable_netboot=true" --set "state_dir=/tmp/auroraboot"
@@ -99,7 +99,7 @@ Then we burn the resulting ISO to a dvd or usb stick and boot it normally.
 
 **In order to have kdump working properly, we need to reserve a chunk of memory from the system so it can dump correctly**. Several tools exist for this like `kdumptool` which will give us some approximated values to reserve if running on the machine. A safe value might be `512M high` and `72M low`
 
-This values need to be passed to the kernel in the cmdline so kdump knows what memory it has to work with. The easiest way is to set the `install.grub_options.extra_cmdline` value in the [cloud-config]({{%relref "/docs/reference/configuration" %}}) during install.
+This values need to be passed to the kernel in the cmdline so kdump knows what memory it has to work with. The easiest way is to set the `install.grub_options.extra_cmdline` value in the [cloud-config]({{< ref "configuration.md" >}}) during install.
 
 ```yaml
 #cloud-config

--- a/content/en/docs/Installation/_index.md
+++ b/content/en/docs/Installation/_index.md
@@ -4,6 +4,6 @@ linkTitle: "Installation"
 icon: fa-regular fa-computer
 weight: 2
 description: |
-    There are many ways to install Kairos on a system. This section will teach you about each of them.
+    Discover multiple ways to install Kairos across cloud, bare metal, and virtualized environments.
 ---
 

--- a/content/en/docs/Installation/azure.md
+++ b/content/en/docs/Installation/azure.md
@@ -7,12 +7,12 @@ description: Install Kairos on Microsoft Azure
 ---
 
 This page describes how to install Kairos on [Microsoft Azure](https://azure.microsoft.com/) after you have created a disk image. Since release v3.3.5, Kairos pipeline is pushing a public OS image to Azure which you can use.
-If you want to build a custom image, you can follow the instructions in the [Build Kairos appliances]({{< relref "../advanced/build" >}}) page.
+If you want to build a custom image, you can follow the instructions in the [Creating Custom Cloud Images]({{< ref "creating_custom_cloud_images.md" >}}) page.
 
 ## Prerequisites
 
 - An Azure account with permissions to create VMs.
-- An Azure compatible image of Kairos. You can use the public image provided by Kairos (see below) or [build your own image]({{< ref "/docs/Reference/auroraboot.md#generate-raw-disk-images" >}}) (for Azure, that would be the `.vhd` format) and upload it to your Azure resource group ([check how the Kairos CI does it](https://github.com/kairos-io/kairos/blob/cbc6e033cda624e61b2050439b1a95c04fbe78de/.github/workflows/upload-cloud-images.yaml#L158-L241)).
+- An Azure compatible image of Kairos. You can use the public image provided by Kairos (see below) or [build your own image]({{< ref "auroraboot.md" >}}#generate-raw-disk-images) (for Azure, that would be the `.vhd` format) and upload it to your Azure resource group ([check how the Kairos CI does it](https://github.com/kairos-io/kairos/blob/cbc6e033cda624e61b2050439b1a95c04fbe78de/.github/workflows/upload-cloud-images.yaml#L158-L241)).
 
 ## Deploy a VM
 
@@ -38,7 +38,7 @@ There are multiple options to select for your VM. We suggest you choose a size t
 - An OS disk size of 30Gb or more (3 times the image size + some more for persistent storage). Don't go with the "Image default" because the disk needs to be large enough to accommodate for active, passive and recovery system.
 - Public inbound port for SSH (if you intend to SSH to the machine later).
 
-Under the "Advanced" tab, click on "Enable user data". In the field that is opened, you can put your [Kairos configuration]({{< ref "/docs/Reference/configuration.md" >}}).
+Under the "Advanced" tab, click on "Enable user data". In the field that is opened, you can put your [Kairos configuration]({{< ref "configuration.md" >}}).
 
 When the instance boots for the first time, it will boot into "auto-reset mode" by default. This means, that Kairos will "install" itself on the first boot and then reboot.
 You can specify a different image to be installed using a block like the following in the cloud config section:

--- a/content/en/docs/Installation/gce.md
+++ b/content/en/docs/Installation/gce.md
@@ -7,12 +7,12 @@ description: Install Kairos on Google Cloud
 ---
 
 This page describes how to install Kairos on Google Cloud after you have created a disk image. Since release v3.3.1, Kairos pipeline is pushing a public OS image to Google Cloud which you can use.
-If you want to build a custom image, you can follow the instructions in the [Build Kairos appliances]({{< ref "build" >}}) page.
+If you want to build a custom image, you can follow the instructions in the [Creating Custom Cloud Images]({{< ref "creating_custom_cloud_images.md" >}}) page.
 
 ## Prerequisites
 
 - A Google Cloud account with permissions to create VMs.
-- A Google Cloud compatible image of Kairos. You can use the public image provided by Kairos (see below) or [build your own image]({{< ref "/docs/Reference/auroraboot.md#generate-raw-disk-images" >}}) and upload it to your google project ([check how the Kairos CI does it](https://github.com/kairos-io/kairos/blob/48d5c2bc8fc5555263f799db8a3388d7d46cd559/.github/workflows/upload-cloud-images.yaml#L36-L89)).
+- A Google Cloud compatible image of Kairos. You can use the public image provided by Kairos (see below) or [build your own image]({{< ref "auroraboot.md" >}}) and upload it to your google project ([check how the Kairos CI does it](https://github.com/kairos-io/kairos/blob/48d5c2bc8fc5555263f799db8a3388d7d46cd559/.github/workflows/upload-cloud-images.yaml#L36-L89)).
 
 ## Deploy a VM
 

--- a/content/en/docs/Installation/takeover.md
+++ b/content/en/docs/Installation/takeover.md
@@ -1,6 +1,7 @@
 ---
 title: "Takeover"
 linkTitle: "Takeover"
+description: Learn how to enable Trusted Boot support in Kairos, which combines FDE, Secure Boot, and Measured Boot to protect your system from tampering and cold attacks.
 weight: 7
 date: 2022-11-13
 ---

--- a/content/en/docs/Installation/trustedboot.md
+++ b/content/en/docs/Installation/trustedboot.md
@@ -1,6 +1,7 @@
 ---
 title: "Trusted Boot Installations"
 linkTitle: "Trusted Boot"
+description: Learn how to enable Trusted Boot with Secure Boot, full disk encryption, and measured boot to protect systems from tampering.
 weight: 6
 date: 2022-11-13
 ---

--- a/content/en/docs/Media/_index.md
+++ b/content/en/docs/Media/_index.md
@@ -3,7 +3,7 @@ title: "Media"
 linkTitle: "Media"
 weight: 9
 icon: fa-regular fa-circle-play
-description: Presentation Slides, Videos and other media on Kairos
+description: Discover Kairos in action through videos, presentation slides, and other media resources.
 ---
 
 ## Articles

--- a/content/en/docs/Reference/_index.md
+++ b/content/en/docs/Reference/_index.md
@@ -4,5 +4,5 @@ linkTitle: "Reference"
 icon: fa-regular fa-book
 weight: 6
 description: |
-    Everything you need to operate your Kairos nodes and a bit more!
+    Access essential reference materials for configuring, building, and troubleshooting Kairos nodes and images.
 ---

--- a/content/en/docs/Reference/architecture.md
+++ b/content/en/docs/Reference/architecture.md
@@ -3,7 +3,7 @@ title: "Architecture"
 linkTitle: "Architecture"
 weight: 1
 date: 2022-11-13
-description: Kairos internal architecture
+description: Explore the internal design of Kairos and how its modular, container-based approach supports secure, reproducible infrastructure.
 ---
 
 This section contains refrences to how Kairos works internally.

--- a/content/en/docs/Reference/auroraboot.md
+++ b/content/en/docs/Reference/auroraboot.md
@@ -6,7 +6,7 @@ description: Reference documentation for AuroraBoot, a tool for generating boota
 ---
 
 {{% alert title="Note" color="info" %}}
-This is the reference documentation for AuroraBoot. For a complete guide on creating custom cloud images, including how to use AuroraBoot in the context of a full workflow, see [Creating Custom Cloud Images]({{< ref "/docs/advanced/creating_custom_cloud_images" >}}).
+This is the reference documentation for AuroraBoot. For a complete guide on creating custom cloud images, including how to use AuroraBoot in the context of a full workflow, see [Creating Custom Cloud Images]({{< ref "creating_custom_cloud_images.md" >}}).
 {{% /alert %}}
 
 **AuroraBoot** is a tool designed to make the process of bootstrapping Kairos machines quick, simple and efficient. It is specifically designed for the Kairos operating system and provides a comprehensive solution for downloading required artifacts and provisioning a machine, both from network or manually via flashing to USB stick. 
@@ -604,10 +604,8 @@ docker run -v "$PWD"/config.yaml:/config.yaml --rm -ti --net host quay.io/kairos
 
 ### Generate RAW disk images
 
-AuroraBoot can generate raw disk images (BIOS/EFI) that can be used as cloud images (for example as AWS AMI images) or QEMU.
-
 {{% alert title="Note" color="success" %}}
-This method differs from the ones documented in the [Build raw images with QEMU]({{< ref "/docs/Reference/build_raw_images_with_qemu" >}}). The raw disk images created with AuroraBoot don't run any installation steps and are ready to use. If you need to run installation steps in order to customize your installation flow, please use the [QEMU example]({{< ref "/docs/Reference/build_raw_images_with_qemu" >}}).
+This method differs from the ones documented in the [Build raw images with QEMU]({{< ref "build_raw_images_with_qemu.md" >}}) section: this method is suitable if you need to create appliances that have to run a full-installation. AuroraBoot will create instead images pre-installed which will skip the usual Kairos installation process in runtime
 {{% /alert %}}
 
 Consider the following example:

--- a/content/en/docs/Reference/build_raw_images_with_qemu.md
+++ b/content/en/docs/Reference/build_raw_images_with_qemu.md
@@ -8,8 +8,10 @@ description: This article shows how to bring your own image with Kairos, and bui
 This page provides a reference guide on how to build raw images for Kairos using QEMU. It covers the process of using a default cloud configuration and a script to generate bootable images. The cloud configuration can be customized to suit different use cases. This mechanism can be used to create golden images, or simply be an alternative to use tools like Packer. 
 
 {{% alert title="Note" color="success" %}}
-This method differs from the ones documented in the [Auroraboot]({{< ref "/docs/Reference/auroraboot" >}}) section: this method is suitable if you need to create appliances that have to run a full-installation. AuroraBoot will create instead images pre-installed which will skip the usual Kairos installation process in runtime
+This method differs from the ones documented in the [Auroraboot]({{< ref "auroraboot.md" >}}) section: this method is suitable if you need to create appliances that have to run a full-installation. AuroraBoot will create instead images pre-installed which will skip the usual Kairos installation process in runtime
 {{% /alert %}}
+
+For more information about AuroraBoot, see the [AuroraBoot Reference]({{< ref "auroraboot.md" >}}).
 
 ## Requirements
 

--- a/content/en/docs/Reference/kairosctl.md
+++ b/content/en/docs/Reference/kairosctl.md
@@ -1,6 +1,7 @@
 ---
 title: "kairosctl"
 linkTitle: "kairosctl"
+description: Learn how to use kairosctl to register nodes, generate tokens, and manage VPN connections securely and efficiently.
 weight: 3
 date: 2022-11-13
 ---

--- a/content/en/docs/Reference/reset.md
+++ b/content/en/docs/Reference/reset.md
@@ -1,6 +1,7 @@
 ---
 title: "Reset a node"
 linkTitle: "Reset"
+description: Discover how to reset a Kairos node using boot options, Kubernetes integration, or recovery tools while preserving config data.
 weight: 4
 date: 2022-11-13
 ---

--- a/content/en/docs/Reference/stage_modules.md
+++ b/content/en/docs/Reference/stage_modules.md
@@ -1,6 +1,7 @@
 ---
 title: "Stage modules"
 linkTitle: "Stage modules"
+description: Explore built-in modules for DNS, users, files, and services that help you customize Kairos via cloud-init during boot stages.
 weight: 3
 date: 2024-09-19
 ---

--- a/content/en/docs/Upgrade/_index.md
+++ b/content/en/docs/Upgrade/_index.md
@@ -4,7 +4,7 @@ linkTitle: "Upgrade"
 icon: fa-regular fa-cloud-arrow-up
 weight: 3
 description: |
-    Keeping your system up-to-date is very important. Learn about the different ways to upgrade a Kairos system
+    Learn how to keep Kairos systems up-to-date using manual methods, Kubernetes-based upgrades, and trusted boot options.
 ---
 
 After your system has been running for a while, you will need to upgrade it to a different version. Check out the following sections to learn the different ways to upgrade Kairos.

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -1,7 +1,7 @@
-
 ---
-title: "Welcome"
+title: "Documentation"
 linkTitle: "Documentation"
+description: "Explore the official documentation for Kairos and discover how it simplifies lifecycle management across edge, cloud, and bare metal environments."
 weight: 20
 menu:
   main:

--- a/content/en/docs/advanced/creating_custom_cloud_images.md
+++ b/content/en/docs/advanced/creating_custom_cloud_images.md
@@ -61,7 +61,7 @@ Once you have a base image, you can customize it by:
 3. Adding custom services
 4. Including additional files
 
-See the [Customizing Images]({{< ref "/docs/advanced/customizing" >}}) guide for detailed instructions.
+See the [Customizing Images]({{< ref "customizing.md" >}}) guide for detailed instructions.
 
 ## Step 3: Building Bootable Images with AuroraBoot
 
@@ -79,7 +79,7 @@ docker run -v "$PWD"/build:/tmp/auroraboot \
 ```
 
 {{% alert title="Note" color="info" %}}
-For more details about AuroraBoot options and configurations, see the [AuroraBoot documentation]({{< ref "/docs/reference/auroraboot" >}}).
+For more details about AuroraBoot options and configurations, see the [AuroraBoot documentation]({{< ref "auroraboot.md" >}}).
 {{% /alert %}}
 
 ### State Partition Sizing
@@ -129,13 +129,13 @@ As explained in the section above, sizing the state partition properly is import
 ## Step 5: Building for Specific Platforms
 
 ### AWS
-To install on AWS, follow the [AWS Guide]({{< ref "/docs/installation/aws" >}}).
+To install on AWS, follow the [AWS Guide]({{< ref "aws.md" >}}).
 
 ### Google Cloud
-To install on Google Cloud, follow the [Google Cloud Installation Guide]({{< ref "/docs/installation/gce" >}}).
+To install on Google Cloud, follow the [Google Cloud Installation Guide]({{< ref "gce.md" >}}).
 
 ### Microsoft Azure
-For Azure deployments, see the [Azure Installation Guide]({{< ref "/docs/installation/azure" >}}).
+For Azure deployments, see the [Azure Installation Guide]({{< ref "azure.md" >}}).
 
 ## Troubleshooting
 
@@ -146,6 +146,6 @@ Common issues and solutions:
 
 ## Next Steps
 
-- [Customizing Images]({{< ref "/docs/advanced/customizing" >}})
-- [AuroraBoot Reference]({{< ref "/docs/reference/auroraboot" >}})
-- [Cloud Configuration Reference]({{< ref "/docs/reference/configuration" >}}) 
+- [Customizing Images]({{< ref "customizing.md" >}})
+- [AuroraBoot Reference]({{< ref "auroraboot.md" >}})
+- [Cloud Configuration Reference]({{< ref "configuration.md" >}}) 

--- a/content/en/getting-started/_index.md
+++ b/content/en/getting-started/_index.md
@@ -9,7 +9,7 @@ menu:
   main:
     weight: 10
 description: |
-    Step-by-step guide to deploying Kairos, the best immutable Linux distribution for edge Kubernetes clusters.
+    Learn how to deploy Kairos, the immutable Linux distribution designed for secure and resilient Kubernetes clusters at the edge.
 ---
 
 {{% alert title="Objective" color="success" %}}
@@ -192,7 +192,7 @@ Kairos uses providers to install Kubernetes distributions. The Kairos provider i
 
 Ready to configure your newly deployed Kairos node?
 
-<a class="btn btn-lg btn-primary me-3 mb-4" href="{{< relref "./configuration" >}}">
+<a class="btn btn-lg btn-primary me-3 mb-4" href="{{< ref "initial-configuration.md" >}}">
     Quick configuration guide
 </a>
 

--- a/content/en/getting-started/building-and-upgrading.md
+++ b/content/en/getting-started/building-and-upgrading.md
@@ -4,7 +4,7 @@ linkTitle: "Building & Upgrading"
 versionBanner: "false"
 weight: 3
 description: |
-    Kairos is an immutable OS so we cannot install new packages on a running system. Instead, adding packages is achieved by building a container image and upgrading the node with it.
+    Learn how to customize Kairos with additional packages and apply upgrades using container-based image workflows.
 ---
 
 {{% alert title="Objective" color="success" %}}

--- a/content/en/getting-started/initial-configuration.md
+++ b/content/en/getting-started/initial-configuration.md
@@ -4,7 +4,7 @@ linkTitle: "Configuration"
 versionBanner: "false"
 weight: 2
 description: |
-  Learn the basics of configuring an immutable OS like Kairos
+    Learn how to configure a fresh Kairos deployment with essential settings for secure and effective operation.
 ---
 
 {{% alert title="Objective" color="success" %}}

--- a/content/en/getting-started/what-is-kairos.md
+++ b/content/en/getting-started/what-is-kairos.md
@@ -4,7 +4,7 @@ linkTitle: "What is Kairos?"
 versionBanner: "false"
 weight: 2
 description: |
-    Find out about the features in Kairos, the goals that drive our project and how to join our community.
+    Discover Kairos’ core features, guiding principles, and how to get involved with the project.
 ---
 
 Kairos is a cloud-native Linux meta-distribution for running Kubernetes. It brings the power of the public cloud to your on-premises environment. With Kairos, you can build your own cloud with complete control and no vendor lock-in.

--- a/content/en/search-index.md
+++ b/content/en/search-index.md
@@ -1,4 +1,5 @@
 ---
 type: "search-index"
 url: "index.json"
+sitemap_exclude: true
 ---

--- a/content/en/search.md
+++ b/content/en/search.md
@@ -1,6 +1,6 @@
 ---
 title: Search Results
 layout: search
-
+sitemap_exclude: true
 ---
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -47,7 +47,7 @@ languageName ="English"
 # Weight used for sorting.
 weight = 1
 [languages.en.params]
-description = "The immutable edge Kubernetes"
+description = "Kairos is an open-source Linux-based operating system designed for securely running Kubernetes at the edge. It provides immutable, declarative infrastructure with features like P2P clustering, trusted boot, and A/B upgrades."
 images = [ "images/Kairos_800x419.png" ]
 
 # language not really in use just a hack to trigger the navbar-lang-selector which at the moment is used for distro selector
@@ -98,6 +98,9 @@ offlineSearch = true
 
 latest_version = "v3.4.2"
 development = true
+
+[params.robots]
+  llmsTXT = true
 
 [params.softwareVersions]
 # renovate: datasource=github-releases depName=kairos-io/provider-kairos

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,11 @@
+User-agent: *
+Sitemap: {{ "sitemap.xml" | absURL }}
+{{ range where .Pages "Params.sitemap_exclude" "eq" true }}
+Disallow: {{ .RelPermalink }}{{ end }}
+
+{{/* LLMS */}}
+{{- $llmsGoTXT := resources.Get "llms.go.txt" -}}
+{{- if and $llmsGoTXT .Site.Params.robots.llmsTXT -}}
+  {{- $llmsTXT := $llmsGoTXT | resources.ExecuteAsTemplate "llms.txt" . -}}
+  llms-txt: {{ $llmsTXT.Permalink }}
+{{- end -}} 


### PR DESCRIPTION
This PR introduces several improvements to the Kairos documentation:

1. Adds a new LLMs.txt template for better documentation indexing and searchability
2. Implements descriptive frontmatter across key documentation pages to improve SEO and user navigation
3. Updates internal documentation links to use the more reliable `ref` shortcode instead of `relref`
4. Excludes certain pages from sitemap generation (blog, community, announcements) to improve search relevance
5. Enhances section descriptions to be more informative and user-focused

fixes kairos-io/kairos#3421