### PR TITLE
Remove dependabot k3s

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -101,7 +101,6 @@ development = true
 [params.softwareVersions]
 # renovate: datasource=github-releases depName=kairos-io/provider-kairos
 provider_version = "v2.13.1"
-# renovate: datasource=github-releases depName=k3s-io/k3s
 k3s_version = "v1.32.3+k3s1"
 kairos_version = "master"
 # renovate: datasource=github-releases depName=kairos-io/osbuilder


### PR DESCRIPTION
this is counter productive, it tells us when there's a new version of k3s but that doesn't mean we have released kairos with that version.