### PR TITLE
Link Netlify Deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # :book: Kairos documentation
 
-The Kairos documentation uses [docsy](https://docsy.dev).
+The Kairos documentation uses [docsy](https://docsy.dev) a hugo theme for documentation. And is deployed using [Netlify](https://app.netlify.com/projects/kairos-io/deploys).
 
 ## Prerequisites
 


### PR DESCRIPTION
 I always have to go in a PR to find the project url and link, so adding it to the readme 