### PR TITLE
feat: enhance release automation with proper version detection

### DIFF
--- a/.github/workflows/release-monitor.yml
+++ b/.github/workflows/release-monitor.yml
@@ -16,9 +16,6 @@ on:
         type: boolean
         default: false
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   check-releases:
     runs-on: ubuntu-latest
@@ -29,6 +26,15 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Set up environment
         run: |
           chmod +x scripts/*.sh
@@ -37,17 +43,18 @@ jobs:
 
       - name: Run release automation
         run: |
+          ARGS="--verbose"
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ -n "${{ github.event.inputs.version }}" ]; then
-              ./scripts/release-automation.sh --version "${{ github.event.inputs.version }}" $([ "${{ github.event.inputs.dry_run }}" = "true" ] && echo "--dry-run")
-            else
-              ./scripts/release-automation.sh $([ "${{ github.event.inputs.dry_run }}" = "true" ] && echo "--dry-run")
+              ARGS="$ARGS --version ${{ github.event.inputs.version }}"
             fi
-          else
-            ./scripts/release-automation.sh
+            if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+              ARGS="$ARGS --dry-run"
+            fi
           fi
+          ./scripts/release-automation.sh $ARGS
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify on failure
         if: failure()

--- a/.github/workflows/release-monitor.yml
+++ b/.github/workflows/release-monitor.yml
@@ -52,7 +52,7 @@ jobs:
               ARGS="$ARGS --dry-run"
             fi
           fi
-          ./scripts/release-automation.sh $ARGS
+          ./scripts/release-automation.sh "$ARGS"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -254,16 +254,16 @@ const config: Config = {
 
   customFields: {
     registryURL: 'quay.io/kairos',
-    hadronFlavorRelease: 'v0.0.4',
+    hadronFlavorRelease: latestVersionCustomFields.hadronFlavorRelease,
     kairosVersion: latestVersion,
     k3sVersion: latestVersionCustomFields.k3sVersion,
     k0sVersion: latestVersionCustomFields.k0sVersion,
     flavorOptions: latestVersionCustomFields.flavorOptions,
-    providerVersion: 'v2.14.0',
+    providerVersion: latestVersionCustomFields.providerVersion,
     latestVersion,
     latestOperatorVersion: latestOperatorVersion ?? null,
-    auroraBootVersion: 'v0.14.0',
-    kairosInitVersion: 'v0.6.2',
+    auroraBootVersion: latestVersionCustomFields.auroraBootVersion,
+    kairosInitVersion: latestVersionCustomFields.kairosInitVersion,
     docsVersionCustomFields: {
       ...docsVersionCustomFields,
     },

--- a/scripts/release-automation.sh
+++ b/scripts/release-automation.sh
@@ -1,42 +1,38 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# Get the directory where the script is located
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 root_dir="${ROOT_DIR:-$(dirname "$SCRIPT_DIR")}"
 
-# Source the utils file
 source "${SCRIPT_DIR}/utils.sh"
 
-# Default values
 DRY_RUN=false
 SPECIFIC_VERSION=""
 VERBOSE=false
 PUSH_CHANGES=true
 
-# Function to display usage
+KEEP_VERSIONS=()
+REMOVED_VERSIONS=()
+
 usage() {
     cat << EOF
 Usage: $0 [OPTIONS]
 
 Options:
-    --version VERSION    Process a specific version (e.g., v3.5.3)
+    --version VERSION    Process a specific version (e.g., v4.0.2)
     --dry-run           Show what would be done without making changes
-    --push=false        Don't push changes to remote (local testing only)
+    --push=false        Don't push changes or open PR (local testing only)
     --verbose           Enable verbose output
     --help              Show this help message
 
 Examples:
-    $0                          # Check for latest release and process if new
-    $0 --version v3.5.3         # Process specific version
-    $0 --dry-run                # Show what would be done
-    $0 --version v3.5.3 --dry-run  # Test specific version processing
-    $0 --version v3.5.3 --push=false  # Test locally without pushing
-
+    $0
+    $0 --version v4.0.2
+    $0 --version v4.0.2 --dry-run
+    $0 --version v4.0.2 --push=false
 EOF
 }
 
-# Parse command line arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
         --version)
@@ -67,24 +63,18 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Logging function
 log() {
     local level="$1"
     shift
     local message="$*"
-    local timestamp=$(date '+%Y-%m-%d %H:%M:%S')
-    
+    local timestamp
+    timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+
     case "$level" in
-        "INFO")
-            echo "[$timestamp] INFO: $message"
-            ;;
-        "WARN")
-            echo "[$timestamp] WARN: $message" >&2
-            ;;
-        "ERROR")
-            echo "[$timestamp] ERROR: $message" >&2
-            ;;
-        "DEBUG")
+        INFO) echo "[$timestamp] INFO: $message" ;;
+        WARN) echo "[$timestamp] WARN: $message" >&2 ;;
+        ERROR) echo "[$timestamp] ERROR: $message" >&2 ;;
+        DEBUG)
             if [ "$VERBOSE" = true ]; then
                 echo "[$timestamp] DEBUG: $message"
             fi
@@ -92,227 +82,576 @@ log() {
     esac
 }
 
-# Function to update hugo.toml with new versions
-update_hugo_toml() {
+version_key() {
     local version="$1"
-    local kairos_init_version="$2"
-    local component_versions="$3"
-    
-    log "INFO" "Updating hugo.toml with version $version"
-    
-    # Create backup
-    cp hugo.toml hugo.toml.backup
-    
-    # Update kairos_version
-    sed -i "s/^kairos_version = \".*\"/kairos_version = \"$version\"/" hugo.toml
-    
-    # Update kairos_init_version
-    sed -i "s/^kairos_init_version = \".*\"/kairos_init_version = \"$kairos_init_version\"/" hugo.toml
-    
-    # Extract component versions from JSON
-    local provider_version=$(echo "$component_versions" | jq -r '.provider_version // empty')
-    local auroraboot_version=$(echo "$component_versions" | jq -r '.auroraboot_version // empty')
-    local k3s_version=$(echo "$component_versions" | jq -r '.k3s_version // empty')
-    
-    # Update provider_version if available
-    if [ -n "$provider_version" ] && [ "$provider_version" != "null" ]; then
-        sed -i "s/^provider_version = \".*\"/provider_version = \"$provider_version\"/" hugo.toml
-        log "INFO" "Updated provider_version to $provider_version"
-    else
-        log "WARN" "provider_version not found or empty"
+    if [[ "$version" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+        echo "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+        return 0
     fi
-    
-    # Update auroraboot_version if available
-    if [ -n "$auroraboot_version" ] && [ "$auroraboot_version" != "null" ]; then
-        sed -i "s/^auroraboot_version = \".*\"/auroraboot_version = \"$auroraboot_version\"/" hugo.toml
-        log "INFO" "Updated auroraboot_version to $auroraboot_version"
-    else
-        log "WARN" "auroraboot_version not found or empty"
-    fi
-    
-    # Update k3s_version if available
-    if [ -n "$k3s_version" ] && [ "$k3s_version" != "null" ]; then
-        sed -i "s/^k3s_version = \".*\"/k3s_version = \"$k3s_version\"/" hugo.toml
-        log "INFO" "Updated k3s_version to $k3s_version"
-    else
-        log "WARN" "k3s_version not found or empty"
-    fi
-    
-    log "INFO" "Successfully updated hugo.toml"
+    return 1
 }
 
-# Function to validate hugo.toml syntax
-validate_hugo_toml() {
-    log "INFO" "Validating hugo.toml syntax"
-    
-    # Check if hugo is available
-    if ! command -v hugo &> /dev/null; then
-        log "WARN" "Hugo not found, skipping syntax validation"
-        return 0
-    fi
-    
-    # Try to parse hugo.toml
-    if hugo config --quiet 2>/dev/null; then
-        log "INFO" "hugo.toml syntax is valid"
-        return 0
-    else
-        log "ERROR" "hugo.toml syntax validation failed"
+list_local_doc_versions() {
+    shopt -s nullglob
+    local path
+    for path in versioned_docs/version-v*; do
+        basename "$path" | sed 's/^version-//'
+    done
+    shopt -u nullglob
+}
+
+contains_version() {
+    local needle="$1"
+    shift
+    local value
+    for value in "$@"; do
+        if [ "$value" = "$needle" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+compute_keep_versions() {
+    local target_version="$1"
+    local -a fetched_versions=()
+    local line
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ release/(v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            fetched_versions+=("${BASH_REMATCH[1]}")
+        fi
+    done < <(fetch_latest_releases)
+
+    fetched_versions+=("$target_version")
+
+    declare -A latest_patch_by_minor=()
+    declare -A latest_version_by_minor=()
+
+    local version major minor patch key
+    for version in "${fetched_versions[@]}"; do
+        if [[ ! "$version" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            continue
+        fi
+
+        major="${BASH_REMATCH[1]}"
+        minor="${BASH_REMATCH[2]}"
+        patch="${BASH_REMATCH[3]}"
+        key="${major}.${minor}"
+
+        if [ -z "${latest_patch_by_minor[$key]+x}" ] || [ "$patch" -gt "${latest_patch_by_minor[$key]}" ]; then
+            latest_patch_by_minor[$key]="$patch"
+            latest_version_by_minor[$key]="$version"
+        fi
+    done
+
+    local -a minor_latest=()
+    local k
+    for k in "${!latest_version_by_minor[@]}"; do
+        minor_latest+=("${latest_version_by_minor[$k]}")
+    done
+
+    if [ "${#minor_latest[@]}" -eq 0 ]; then
         return 1
     fi
+
+    mapfile -t minor_latest < <(printf '%s\n' "${minor_latest[@]}" | sort -V)
+
+    local count=${#minor_latest[@]}
+    local start=0
+    if [ "$count" -gt 3 ]; then
+        start=$((count - 3))
+    fi
+
+    KEEP_VERSIONS=()
+    local i
+    for ((i=start; i<count; i++)); do
+        KEEP_VERSIONS+=("${minor_latest[$i]}")
+    done
 }
 
-# Function to create release branch and commit changes
-create_release_branch() {
+ensure_release_branch() {
     local version="$1"
     local branch_name="release/$version"
-    
-    log "INFO" "Creating release branch: $branch_name"
-    
+
     if [ "$DRY_RUN" = true ]; then
-        log "INFO" "[DRY RUN] Would create branch: $branch_name"
-        log "INFO" "[DRY RUN] Would commit changes to hugo.toml"
-        if [ "$PUSH_CHANGES" = true ]; then
-            log "INFO" "[DRY RUN] Would push branch to origin"
-        else
-            log "INFO" "[DRY RUN] Would skip pushing (--push=false)"
-        fi
+        log "INFO" "[DRY RUN] Would checkout/create branch: $branch_name"
         return 0
     fi
-    
-    # Create and checkout new branch
-    git checkout -b "$branch_name"
-    
-    # Add and commit changes
-    git add hugo.toml
-    git commit -m "chore: update versions for release $version"
-    
-    # Push branch to origin only if PUSH_CHANGES is true
-    if [ "$PUSH_CHANGES" = true ]; then
-        git push -u origin "$branch_name"
-        log "INFO" "Successfully created and pushed release branch: $branch_name"
-    else
-        log "INFO" "Successfully created release branch: $branch_name (not pushed - use --push=false to test locally)"
+
+    local current_branch
+    current_branch=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$current_branch" = "$branch_name" ]; then
+        log "INFO" "Already on branch $branch_name"
+        return 0
     fi
+
+    if git show-ref --verify --quiet "refs/heads/$branch_name"; then
+        git checkout "$branch_name"
+    elif git show-ref --verify --quiet "refs/remotes/origin/$branch_name"; then
+        git checkout -b "$branch_name" --track "origin/$branch_name"
+    else
+        git checkout -b "$branch_name"
+    fi
+
+    log "INFO" "Using branch $branch_name"
 }
 
-# Function to process a specific version
+create_docs_version_if_missing() {
+    local version="$1"
+    if [ -d "versioned_docs/version-$version" ]; then
+        log "INFO" "Versioned docs already exist for $version"
+        return 0
+    fi
+
+    if [ "$DRY_RUN" = true ]; then
+        log "INFO" "[DRY RUN] Would run: npm run docusaurus docs:version $version"
+        return 0
+    fi
+
+    log "INFO" "Creating Docusaurus docs version for $version"
+    npm run docusaurus -- docs:version "$version"
+}
+
+delete_docs_version() {
+    local version="$1"
+    if [ "$DRY_RUN" = true ]; then
+        log "INFO" "[DRY RUN] Would delete versioned_docs/version-$version"
+        log "INFO" "[DRY RUN] Would delete versioned_sidebars/version-$version-sidebars.json"
+        return 0
+    fi
+
+    rm -rf "versioned_docs/version-$version"
+    rm -f "versioned_sidebars/version-$version-sidebars.json"
+    log "INFO" "Removed docs artifacts for $version"
+}
+
+sync_versions_json() {
+    if [ "$DRY_RUN" = true ]; then
+        log "INFO" "[DRY RUN] Would rewrite versions.json from versioned_docs folders"
+        return 0
+    fi
+
+    node - <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = process.cwd();
+const dir = path.join(root, 'versioned_docs');
+const versionsPath = path.join(root, 'versions.json');
+
+const versions = fs.existsSync(dir)
+  ? fs
+      .readdirSync(dir, {withFileTypes: true})
+      .filter((entry) => entry.isDirectory() && entry.name.startsWith('version-v'))
+      .map((entry) => entry.name.replace(/^version-/, ''))
+  : [];
+
+const parsed = versions
+  .map((version) => {
+    const match = version.match(/^v(\d+)\.(\d+)\.(\d+)$/);
+    if (!match) return null;
+    return {
+      raw: version,
+      major: Number.parseInt(match[1], 10),
+      minor: Number.parseInt(match[2], 10),
+      patch: Number.parseInt(match[3], 10),
+    };
+  })
+  .filter(Boolean)
+  .sort((a, b) => {
+    if (a.major !== b.major) return b.major - a.major;
+    if (a.minor !== b.minor) return b.minor - a.minor;
+    return b.patch - a.patch;
+  })
+  .map((v) => v.raw);
+
+fs.writeFileSync(versionsPath, `${JSON.stringify(parsed, null, 2)}\n`);
+NODE
+}
+
+update_docusaurus_config() {
+    local target_version="$1"
+    local kairos_init_version="$2"
+    local component_versions_json="$3"
+
+    local provider_version
+    local auroraboot_version
+    local hadron_version
+    local k3s_version
+    provider_version=$(echo "$component_versions_json" | jq -r '.provider_version')
+    auroraboot_version=$(echo "$component_versions_json" | jq -r '.auroraboot_version')
+    hadron_version=$(echo "$component_versions_json" | jq -r '.hadron_version')
+    k3s_version=$(echo "$component_versions_json" | jq -r '.k3s_version')
+
+    if [ "$DRY_RUN" = true ]; then
+        log "INFO" "[DRY RUN] Would sync docsVersionCustomFields in docusaurus.config.ts"
+        log "INFO" "[DRY RUN] Would update banner to $target_version"
+        return 0
+    fi
+
+    TARGET_VERSION="$target_version" \
+    KAIROS_INIT_VERSION="$kairos_init_version" \
+    PROVIDER_VERSION="$provider_version" \
+    AURORABOOT_VERSION="$auroraboot_version" \
+    HADRON_VERSION="$hadron_version" \
+    K3S_VERSION="$k3s_version" \
+    node - <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+
+const configPath = path.join(process.cwd(), 'docusaurus.config.ts');
+const source = fs.readFileSync(configPath, 'utf8');
+
+const targetVersion = process.env.TARGET_VERSION;
+const kairosInitVersion = process.env.KAIROS_INIT_VERSION;
+const providerVersion = process.env.PROVIDER_VERSION;
+const auroraBootVersion = process.env.AURORABOOT_VERSION;
+const hadronVersion = process.env.HADRON_VERSION;
+const k3sVersion = process.env.K3S_VERSION;
+
+function coalesce(value, fallback) {
+  return typeof value === 'string' && value.length > 0 ? value : fallback;
+}
+
+const versionsDir = path.join(process.cwd(), 'versioned_docs');
+const folderVersions = fs.existsSync(versionsDir)
+  ? fs
+      .readdirSync(versionsDir, {withFileTypes: true})
+      .filter((entry) => entry.isDirectory() && entry.name.startsWith('version-v'))
+      .map((entry) => entry.name.replace(/^version-/, ''))
+  : [];
+
+if (!folderVersions.includes(targetVersion)) {
+  throw new Error(`Target version ${targetVersion} missing from versioned_docs`);
+}
+
+const parsedFolderVersions = folderVersions
+  .map((version) => {
+    const match = version.match(/^v(\d+)\.(\d+)\.(\d+)$/);
+    if (!match) return null;
+    return {
+      raw: version,
+      major: Number.parseInt(match[1], 10),
+      minor: Number.parseInt(match[2], 10),
+      patch: Number.parseInt(match[3], 10),
+    };
+  })
+  .filter(Boolean)
+  .sort((a, b) => {
+    if (a.major !== b.major) return b.major - a.major;
+    if (a.minor !== b.minor) return b.minor - a.minor;
+    return b.patch - a.patch;
+  })
+  .map((v) => v.raw);
+
+const docsFieldMatch = source.match(/const docsVersionCustomFields = \{([\s\S]*?)\} as const;/);
+if (!docsFieldMatch) {
+  throw new Error('Unable to locate docsVersionCustomFields in docusaurus.config.ts');
+}
+
+const existingBlock = docsFieldMatch[1];
+const entryRegex = /'(?<version>v\d+\.\d+\.\d+)':\s*\{(?<body>[\s\S]*?)\n\s*\},?/g;
+const existing = new Map();
+
+function extractString(body, key) {
+  const m = body.match(new RegExp(`${key}:\\s*'([^']*)'`));
+  return m ? m[1] : null;
+}
+
+function extractNullable(body, key) {
+  const m = body.match(new RegExp(`${key}:\\s*(null|'[^']*')`));
+  if (!m) return null;
+  if (m[1] === 'null') return null;
+  return m[1].slice(1, -1);
+}
+
+function extractIdentifier(body, key) {
+  const m = body.match(new RegExp(`${key}:\\s*([A-Za-z0-9_]+)`));
+  return m ? m[1] : null;
+}
+
+let match;
+while ((match = entryRegex.exec(existingBlock)) !== null) {
+  const version = match.groups.version;
+  const body = match.groups.body;
+  const item = {
+    registryURL: extractString(body, 'registryURL'),
+    hadronFlavorRelease: extractNullable(body, 'hadronFlavorRelease'),
+    k3sVersion: extractString(body, 'k3sVersion'),
+    flavorOptions: extractIdentifier(body, 'flavorOptions'),
+    providerVersion: extractString(body, 'providerVersion'),
+    auroraBootVersion: extractString(body, 'auroraBootVersion'),
+    kairosInitVersion: extractString(body, 'kairosInitVersion'),
+  };
+  existing.set(version, item);
+}
+
+if (existing.size === 0) {
+  throw new Error('No docsVersionCustomFields entries found');
+}
+
+const templateVersion = parsedFolderVersions.find((v) => v !== targetVersion && existing.has(v))
+  ?? [...existing.keys()].sort((a, b) => {
+    const am = a.match(/^v(\d+)\.(\d+)\.(\d+)$/);
+    const bm = b.match(/^v(\d+)\.(\d+)\.(\d+)$/);
+    if (!am || !bm) return 0;
+    if (am[1] !== bm[1]) return Number.parseInt(bm[1], 10) - Number.parseInt(am[1], 10);
+    if (am[2] !== bm[2]) return Number.parseInt(bm[2], 10) - Number.parseInt(am[2], 10);
+    return Number.parseInt(bm[3], 10) - Number.parseInt(am[3], 10);
+  })[0];
+
+const template = existing.get(templateVersion);
+if (!template) {
+  throw new Error('Unable to select template docsVersionCustomFields entry');
+}
+
+const normalizedEntries = new Map();
+for (const version of parsedFolderVersions) {
+  if (version === targetVersion) {
+    normalizedEntries.set(version, {
+      registryURL: template.registryURL,
+      hadronFlavorRelease: coalesce(hadronVersion, template.hadronFlavorRelease),
+      k3sVersion: coalesce(k3sVersion, template.k3sVersion),
+      flavorOptions: template.flavorOptions,
+      providerVersion: coalesce(providerVersion, template.providerVersion),
+      auroraBootVersion: coalesce(auroraBootVersion, template.auroraBootVersion),
+      kairosInitVersion: coalesce(kairosInitVersion, template.kairosInitVersion),
+    });
+    continue;
+  }
+
+  const current = existing.get(version);
+  if (!current) {
+    normalizedEntries.set(version, {
+      registryURL: template.registryURL,
+      hadronFlavorRelease: template.hadronFlavorRelease,
+      k3sVersion: template.k3sVersion,
+      flavorOptions: template.flavorOptions,
+      providerVersion: template.providerVersion,
+      auroraBootVersion: template.auroraBootVersion,
+      kairosInitVersion: template.kairosInitVersion,
+    });
+  } else {
+    normalizedEntries.set(version, current);
+  }
+}
+
+const lines = [];
+for (const version of parsedFolderVersions) {
+  const cfg = normalizedEntries.get(version);
+  lines.push(`  '${version}': {`);
+  lines.push(`    registryURL: '${cfg.registryURL}',`);
+  if (cfg.hadronFlavorRelease === null) {
+    lines.push('    hadronFlavorRelease: null,');
+  } else {
+    lines.push(`    hadronFlavorRelease: '${cfg.hadronFlavorRelease}',`);
+  }
+  lines.push(`    k3sVersion: '${cfg.k3sVersion}',`);
+  lines.push(`    flavorOptions: ${cfg.flavorOptions},`);
+  lines.push(`    providerVersion: '${cfg.providerVersion}',`);
+  lines.push(`    auroraBootVersion: '${cfg.auroraBootVersion}',`);
+  lines.push(`    kairosInitVersion: '${cfg.kairosInitVersion}',`);
+  lines.push('  },');
+}
+
+const newDocsVersionCustomFields = `const docsVersionCustomFields = {\n${lines.join('\n')}\n} as const;`;
+
+let updated = source.replace(/const docsVersionCustomFields = \{[\s\S]*?\} as const;/, newDocsVersionCustomFields);
+
+const releaseUrl = `https://github.com/kairos-io/kairos/releases/tag/${targetVersion}`;
+const bannerContent = `<a href="${releaseUrl}">Kairos ${targetVersion}</a> is out! 🚀`;
+updated = updated.replace(
+  /content:\s*'[^']*',/,
+  `content: '${bannerContent}',`,
+);
+
+fs.writeFileSync(configPath, updated);
+NODE
+
+    log "INFO" "Updated docusaurus.config.ts for version $target_version"
+}
+
+prune_versions_to_keep() {
+    local -a local_versions=()
+    mapfile -t local_versions < <(list_local_doc_versions | sort -V)
+
+    REMOVED_VERSIONS=()
+    local version
+    for version in "${local_versions[@]}"; do
+        if ! contains_version "$version" "${KEEP_VERSIONS[@]}"; then
+            REMOVED_VERSIONS+=("$version")
+            delete_docs_version "$version"
+        fi
+    done
+}
+
+validate_site_build() {
+    if [ "$DRY_RUN" = true ]; then
+        log "INFO" "[DRY RUN] Would run: npm run build"
+        return 0
+    fi
+
+    log "INFO" "Validating Docusaurus build"
+    npm run build
+}
+
+format_csv() {
+    local -a values=("$@")
+    if [ "${#values[@]}" -eq 0 ]; then
+        echo "none"
+        return 0
+    fi
+    local IFS=", "
+    echo "${values[*]}"
+}
+
+commit_push_and_open_pr() {
+    local version="$1"
+    local component_versions_json="$2"
+    local branch_name="release/$version"
+
+    local provider_version
+    local auroraboot_version
+    local k3s_version
+    provider_version=$(echo "$component_versions_json" | jq -r '.provider_version')
+    auroraboot_version=$(echo "$component_versions_json" | jq -r '.auroraboot_version')
+    k3s_version=$(echo "$component_versions_json" | jq -r '.k3s_version')
+
+    if [ "$DRY_RUN" = true ]; then
+        log "INFO" "[DRY RUN] Would commit docs version updates"
+        log "INFO" "[DRY RUN] Would push $branch_name and open PR"
+        return 0
+    fi
+
+    if git diff --quiet && git diff --cached --quiet; then
+        log "INFO" "No changes detected after processing $version"
+        return 0
+    fi
+
+    git add versions.json docusaurus.config.ts versioned_docs versioned_sidebars
+    git commit -m "chore: update docs versions for $version"
+
+    if [ "$PUSH_CHANGES" = false ]; then
+        log "INFO" "Skipping push and PR creation (--push=false)"
+        return 0
+    fi
+
+    git push -u origin "$branch_name"
+
+    local pr_title="chore: release docs updates for $version"
+    local kept_csv
+    local removed_csv
+    kept_csv=$(format_csv "${KEEP_VERSIONS[@]}")
+    removed_csv=$(format_csv "${REMOVED_VERSIONS[@]}")
+    local release_url="https://github.com/kairos-io/kairos/releases/tag/$version"
+
+    if gh pr view "$branch_name" --json url --jq '.url' >/dev/null 2>&1; then
+        local existing_url
+        existing_url=$(gh pr view "$branch_name" --json url --jq '.url')
+        log "INFO" "PR already exists: $existing_url"
+        return 0
+    fi
+
+    local pr_url
+    pr_url=$(gh pr create --base main --head "$branch_name" --title "$pr_title" --body "$(cat <<EOF
+## Summary
+- Added Docusaurus docs version for $version (if missing)
+- Enforced retention policy: latest patch of the last 3 major.minor lines
+- Synced \\`docsVersionCustomFields\\` and updated announcement banner
+
+## Details
+- Kept versions: $kept_csv
+- Removed versions: $removed_csv
+- Banner release URL: $release_url
+- Extracted component versions: provider=$provider_version, auroraboot=$auroraboot_version, k3s=$k3s_version
+EOF
+)")
+
+    log "INFO" "Created PR: $pr_url"
+}
+
 process_version() {
     local version="$1"
-    
+
     log "INFO" "Processing version: $version"
-    
-    # Validate version format
+
     if ! validate_semantic_version "$version"; then
         log "ERROR" "Invalid semantic version format: $version"
         return 1
     fi
-    
-    # Check if release branch already exists
-    if release_branch_exists "$version"; then
-        log "WARN" "Release branch for $version already exists, skipping"
+
+    if [[ "$version" == *-* ]]; then
+        log "WARN" "Skipping prerelease version: $version"
         return 0
     fi
-    
-    # Get KAIROS_INIT version
-    log "INFO" "Fetching KAIROS_INIT version for $version"
+
+    compute_keep_versions "$version"
+    log "INFO" "Retention keep list (latest patch of last 3 major.minor): $(format_csv "${KEEP_VERSIONS[@]}")"
+
+    ensure_release_branch "$version"
+
     local kairos_init_version
     kairos_init_version=$(get_kairos_init_version "$version")
-    
-    if [ $? -ne 0 ] || [ -z "$kairos_init_version" ]; then
+    if [ -z "$kairos_init_version" ]; then
         log "ERROR" "Failed to get KAIROS_INIT version for $version"
         return 1
     fi
-    
     log "INFO" "Found KAIROS_INIT version: $kairos_init_version"
-    
-    # Get component versions
-    log "INFO" "Fetching component versions from kairos-init $kairos_init_version"
+
     local component_versions
     component_versions=$(get_component_versions "$kairos_init_version" "$version")
-    
-    if [ $? -ne 0 ]; then
-        log "ERROR" "Failed to get component versions for kairos-init $kairos_init_version"
-        return 1
-    fi
-    
     log "DEBUG" "Component versions: $component_versions"
-    
-    # Update hugo.toml
-    update_hugo_toml "$version" "$kairos_init_version" "$component_versions"
-    
-    # Validate hugo.toml
-    if ! validate_hugo_toml; then
-        log "ERROR" "hugo.toml validation failed, reverting changes"
-        mv hugo.toml.backup hugo.toml
-        return 1
-    fi
-    
-    # Create release branch
-    create_release_branch "$version"
-    
-    # Clean up backup
-    rm -f hugo.toml.backup
-    
+
+    create_docs_version_if_missing "$version"
+    prune_versions_to_keep
+    sync_versions_json
+    update_docusaurus_config "$version" "$kairos_init_version" "$component_versions"
+    validate_site_build
+    commit_push_and_open_pr "$version" "$component_versions"
+
     log "INFO" "Successfully processed version: $version"
 }
 
-# Function to check for new releases
 check_for_new_releases() {
     log "INFO" "Checking for new Kairos releases"
-    
-    # Get latest release from GitHub
+
     local latest_release
     latest_release=$(get_latest_kairos_release)
-    
-    if [ $? -ne 0 ] || [ -z "$latest_release" ]; then
-        log "ERROR" "Failed to get latest release from GitHub"
+    if [ -z "$latest_release" ]; then
+        log "ERROR" "Failed to get latest release"
         return 1
     fi
-    
+
     log "INFO" "Latest release from GitHub: $latest_release"
-    
-    # Check if we already have a branch for this release
-    if release_branch_exists "$latest_release"; then
-        log "INFO" "Release branch for $latest_release already exists, no action needed"
-        return 0
-    fi
-    
-    log "INFO" "New release detected: $latest_release"
     process_version "$latest_release"
 }
 
-# Main execution
 main() {
-    log "INFO" "Starting release automation"
+    log "INFO" "Starting Docusaurus release automation"
     log "INFO" "Dry run mode: $DRY_RUN"
     log "INFO" "Push changes: $PUSH_CHANGES"
     log "INFO" "Verbose mode: $VERBOSE"
-    
-    # Change to repository root
+
     cd "$root_dir"
-    
-    # Check if we're in a git repository
+
     if ! git rev-parse --git-dir > /dev/null 2>&1; then
         log "ERROR" "Not in a git repository"
         exit 1
     fi
-    
-    # Check if hugo.toml exists
-    if [ ! -f "hugo.toml" ]; then
-        log "ERROR" "hugo.toml not found in repository root"
+
+    if [ ! -f "docusaurus.config.ts" ]; then
+        log "ERROR" "docusaurus.config.ts not found in repository root"
         exit 1
     fi
-    
-    # Process specific version or check for new releases
+
     if [ -n "$SPECIFIC_VERSION" ]; then
         process_version "$SPECIFIC_VERSION"
     else
         check_for_new_releases
     fi
-    
+
     log "INFO" "Release automation completed"
 }
 
-# Run main function
 main "$@"
-

--- a/scripts/release-automation.sh
+++ b/scripts/release-automation.sh
@@ -379,6 +379,7 @@ while ((match = entryRegex.exec(existingBlock)) !== null) {
     registryURL: extractString(body, 'registryURL'),
     hadronFlavorRelease: extractNullable(body, 'hadronFlavorRelease'),
     k3sVersion: extractString(body, 'k3sVersion'),
+    k0sVersion: extractString(body, 'k0sVersion'),
     flavorOptions: extractIdentifier(body, 'flavorOptions'),
     providerVersion: extractString(body, 'providerVersion'),
     auroraBootVersion: extractString(body, 'auroraBootVersion'),
@@ -413,6 +414,7 @@ for (const version of parsedFolderVersions) {
       registryURL: template.registryURL,
       hadronFlavorRelease: coalesce(hadronVersion, template.hadronFlavorRelease),
       k3sVersion: coalesce(k3sVersion, template.k3sVersion),
+      k0sVersion: template.k0sVersion,
       flavorOptions: template.flavorOptions,
       providerVersion: coalesce(providerVersion, template.providerVersion),
       auroraBootVersion: coalesce(auroraBootVersion, template.auroraBootVersion),
@@ -427,6 +429,7 @@ for (const version of parsedFolderVersions) {
       registryURL: template.registryURL,
       hadronFlavorRelease: template.hadronFlavorRelease,
       k3sVersion: template.k3sVersion,
+      k0sVersion: template.k0sVersion,
       flavorOptions: template.flavorOptions,
       providerVersion: template.providerVersion,
       auroraBootVersion: template.auroraBootVersion,
@@ -448,6 +451,7 @@ for (const version of parsedFolderVersions) {
     lines.push(`    hadronFlavorRelease: '${cfg.hadronFlavorRelease}',`);
   }
   lines.push(`    k3sVersion: '${cfg.k3sVersion}',`);
+  lines.push(`    k0sVersion: '${cfg.k0sVersion}',`);
   lines.push(`    flavorOptions: ${cfg.flavorOptions},`);
   lines.push(`    providerVersion: '${cfg.providerVersion}',`);
   lines.push(`    auroraBootVersion: '${cfg.auroraBootVersion}',`);

--- a/scripts/release-automation.sh
+++ b/scripts/release-automation.sh
@@ -270,10 +270,12 @@ update_docusaurus_config() {
     local auroraboot_version
     local hadron_version
     local k3s_version
+    local k0s_version
     provider_version=$(echo "$component_versions_json" | jq -r '.provider_version')
     auroraboot_version=$(echo "$component_versions_json" | jq -r '.auroraboot_version')
     hadron_version=$(echo "$component_versions_json" | jq -r '.hadron_version')
     k3s_version=$(echo "$component_versions_json" | jq -r '.k3s_version')
+    k0s_version=$(echo "$component_versions_json" | jq -r '.k0s_version')
 
     if [ "$DRY_RUN" = true ]; then
         log "INFO" "[DRY RUN] Would sync docsVersionCustomFields in docusaurus.config.ts"
@@ -287,6 +289,7 @@ update_docusaurus_config() {
     AURORABOOT_VERSION="$auroraboot_version" \
     HADRON_VERSION="$hadron_version" \
     K3S_VERSION="$k3s_version" \
+    K0S_VERSION="$k0s_version" \
     node - <<'NODE'
 const fs = require('node:fs');
 const path = require('node:path');
@@ -300,6 +303,7 @@ const providerVersion = process.env.PROVIDER_VERSION;
 const auroraBootVersion = process.env.AURORABOOT_VERSION;
 const hadronVersion = process.env.HADRON_VERSION;
 const k3sVersion = process.env.K3S_VERSION;
+const k0sVersion = process.env.K0S_VERSION;
 
 function coalesce(value, fallback) {
   return typeof value === 'string' && value.length > 0 ? value : fallback;
@@ -405,7 +409,7 @@ for (const version of parsedFolderVersions) {
       registryURL: template.registryURL,
       hadronFlavorRelease: coalesce(hadronVersion, template.hadronFlavorRelease),
       k3sVersion: coalesce(k3sVersion, template.k3sVersion),
-      k0sVersion: template.k0sVersion,
+      k0sVersion: coalesce(k0sVersion, template.k0sVersion),
       flavorOptions: template.flavorOptions,
       providerVersion: coalesce(providerVersion, template.providerVersion),
       auroraBootVersion: coalesce(auroraBootVersion, template.auroraBootVersion),

--- a/scripts/release-automation.sh
+++ b/scripts/release-automation.sh
@@ -82,15 +82,6 @@ log() {
     esac
 }
 
-version_key() {
-    local version="$1"
-    if [[ "$version" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-        echo "${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-        return 0
-    fi
-    return 1
-}
-
 list_local_doc_versions() {
     shopt -s nullglob
     local path

--- a/scripts/test-release-automation.sh
+++ b/scripts/test-release-automation.sh
@@ -1,162 +1,87 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# Get the directory where the script is located
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 root_dir="${ROOT_DIR:-$(dirname "$SCRIPT_DIR")}"
 
-# Source the utils file
 source "${SCRIPT_DIR}/utils.sh"
 
-# Test configuration
-TEST_VERSION="v3.5.2"  # Use a known existing version for testing
+TEST_VERSION="v3.5.2"
 
-echo "Testing Release Automation System"
-echo "================================="
+echo "Testing Docusaurus Release Automation"
+echo "====================================="
 echo ""
 
-# Test 1: Validate semantic version function
 echo "Test 1: Semantic version validation"
 echo "-----------------------------------"
 if validate_semantic_version "v3.5.2"; then
-    echo "✓ Valid version 'v3.5.2' passed validation"
+  echo "✓ Valid version accepted"
 else
-    echo "✗ Valid version 'v3.5.2' failed validation"
+  echo "✗ Valid version rejected"
 fi
 
 if ! validate_semantic_version "invalid-version"; then
-    echo "✓ Invalid version 'invalid-version' correctly rejected"
+  echo "✓ Invalid version rejected"
 else
-    echo "✗ Invalid version 'invalid-version' incorrectly accepted"
+  echo "✗ Invalid version accepted"
 fi
 echo ""
 
-# Test 2: Get latest release from GitHub API
-echo "Test 2: GitHub API integration"
-echo "------------------------------"
-echo "Fetching latest release from GitHub API..."
+echo "Test 2: Latest release detection"
+echo "--------------------------------"
 latest_release=$(get_latest_kairos_release)
-if [ $? -eq 0 ] && [ -n "$latest_release" ]; then
-    echo "✓ Successfully fetched latest release: $latest_release"
+if [ -n "$latest_release" ]; then
+  echo "✓ Latest release: $latest_release"
 else
-    echo "✗ Failed to fetch latest release from GitHub API"
+  echo "✗ Could not read latest release"
 fi
 echo ""
 
-# Test 3: Extract KAIROS_INIT version
-echo "Test 3: KAIROS_INIT version extraction"
-echo "--------------------------------------"
-echo "Extracting KAIROS_INIT version for $TEST_VERSION..."
+echo "Test 3: Component version extraction"
+echo "------------------------------------"
 kairos_init_version=$(get_kairos_init_version "$TEST_VERSION")
-if [ $? -eq 0 ] && [ -n "$kairos_init_version" ]; then
-    echo "✓ Successfully extracted KAIROS_INIT version: $kairos_init_version"
-else
-    echo "✗ Failed to extract KAIROS_INIT version for $TEST_VERSION"
-fi
-echo ""
-
-# Test 4: Extract component versions
 if [ -n "$kairos_init_version" ]; then
-    echo "Test 4: Component version extraction"
-    echo "------------------------------------"
-    echo "Extracting component versions for kairos-init $kairos_init_version..."
-    component_versions=$(get_component_versions "$kairos_init_version" "$TEST_VERSION")
-    if [ $? -eq 0 ] && [ -n "$component_versions" ]; then
-        echo "✓ Successfully extracted component versions:"
-        echo "$component_versions" | jq '.'
-    else
-        echo "✗ Failed to extract component versions for kairos-init $kairos_init_version"
-    fi
+  echo "✓ KAIROS_INIT: $kairos_init_version"
 else
-    echo "Test 4: Skipped (no KAIROS_INIT version available)"
+  echo "✗ Could not read KAIROS_INIT"
+fi
+
+component_versions=$(get_component_versions "$kairos_init_version" "$TEST_VERSION")
+if [ -n "$component_versions" ]; then
+  echo "✓ Component versions extracted"
+  echo "$component_versions" | jq '.'
+else
+  echo "✗ Could not extract component versions"
 fi
 echo ""
 
-# Test 4.1: Test component version extraction without kairos_version (should fail)
-echo "Test 4.1: Component version extraction without kairos_version"
-echo "------------------------------------------------------------"
-if [ -n "$kairos_init_version" ]; then
-    echo "Testing component version extraction without kairos_version parameter..."
-    if get_component_versions "$kairos_init_version" >/dev/null 2>&1; then
-        echo "✗ Should have failed when kairos_version is not provided"
-    else
-        echo "✓ Correctly failed when kairos_version is not provided"
-    fi
+echo "Test 4: Retention source (latest patch per major.minor)"
+echo "--------------------------------------------------------"
+if releases=$(fetch_latest_releases); then
+  echo "✓ fetch_latest_releases output:"
+  echo "$releases"
 else
-    echo "Test 4.1: Skipped (no KAIROS_INIT version available)"
+  echo "✗ fetch_latest_releases failed"
 fi
 echo ""
 
-# Test 4.2: Test K3s version extraction from release
-echo "Test 4.2: K3s version extraction from release"
-echo "---------------------------------------------"
-echo "Extracting K3s version from release $TEST_VERSION..."
-k3s_version=$(get_k3s_version_from_release "$TEST_VERSION")
-if [ $? -eq 0 ] && [ -n "$k3s_version" ]; then
-    echo "✓ Successfully extracted K3s version: $k3s_version"
-else
-    echo "✗ Failed to extract K3s version from release $TEST_VERSION"
-fi
-echo ""
-
-# Test 4.3: Test K3s version extraction with invalid version (should fail)
-echo "Test 4.3: K3s version extraction with invalid version"
-echo "----------------------------------------------------"
-echo "Testing K3s version extraction with invalid version..."
-if get_k3s_version_from_release "v999.999.999" >/dev/null 2>&1; then
-    echo "✗ Should have failed when trying to extract K3s version from non-existent release"
-else
-    echo "✓ Correctly failed when trying to extract K3s version from non-existent release"
-fi
-echo ""
-
-# Test 5: Check if release branch exists
-echo "Test 5: Release branch existence check"
-echo "--------------------------------------"
-echo "Checking if release branch exists for $TEST_VERSION..."
-if release_branch_exists "$TEST_VERSION"; then
-    echo "✓ Release branch for $TEST_VERSION exists"
-else
-    echo "ℹ Release branch for $TEST_VERSION does not exist (this is expected for testing)"
-fi
-echo ""
-
-# Test 6: Dry run of the main automation script
-echo "Test 6: Dry run of release automation"
-echo "-------------------------------------"
-echo "Running release automation in dry-run mode for $TEST_VERSION..."
+echo "Test 5: Release automation dry run"
+echo "----------------------------------"
 cd "$root_dir"
 if ./scripts/release-automation.sh --version "$TEST_VERSION" --dry-run --verbose; then
-    echo "✓ Dry run completed successfully"
+  echo "✓ Dry run completed"
 else
-    echo "✗ Dry run failed"
+  echo "✗ Dry run failed"
 fi
 echo ""
 
-# Test 7: Hugo.toml syntax validation
-echo "Test 7: Hugo.toml syntax validation"
-echo "-----------------------------------"
-if command -v hugo &> /dev/null; then
-    if hugo config --quiet 2>/dev/null; then
-        echo "✓ Hugo.toml syntax is valid"
-    else
-        echo "✗ Hugo.toml syntax validation failed"
-    fi
+echo "Test 6: Docusaurus config smoke check"
+echo "--------------------------------------"
+if npm run build >/dev/null 2>&1; then
+  echo "✓ Docusaurus build succeeded"
 else
-    echo "ℹ Hugo not available, skipping syntax validation"
+  echo "✗ Docusaurus build failed"
 fi
 echo ""
 
-echo "Test Summary"
-echo "============"
-echo "All tests completed. Check the output above for any failures."
-echo ""
-echo "To run the automation manually:"
-echo "  ./scripts/release-automation.sh --help"
-echo ""
-echo "To test with a specific version:"
-echo "  ./scripts/release-automation.sh --version v3.5.3 --dry-run"
-echo ""
-echo "To run the automation normally:"
-echo "  ./scripts/release-automation.sh"
-
+echo "Done"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -152,6 +152,44 @@ get_latest_auroraboot_version() {
 # Arguments:
 #   $1: kairos_version (e.g., v4.0.3)
 # Returns: Hadron version (e.g., v0.0.4) or empty string on error
+# Function to extract k0s version from GitHub release artifacts
+# Arguments:
+#   $1: kairos_version (e.g., v4.0.1)
+# Returns: k0s version (e.g., v1.34.4+k0s.0) or empty string if not found
+get_k0s_version_from_release() {
+    local kairos_version="$1"
+    local api_url="https://api.github.com/repos/kairos-io/kairos/releases/tags/$kairos_version"
+    local response
+    
+    if ! response=$(_curl_github "$api_url"); then
+        echo "Error: Failed to fetch release data for version $kairos_version" >&2
+        return 1
+    fi
+    
+    # Extract artifact names that contain "+k0s"
+    local k0s_versions=$(echo "$response" | jq -r '.assets[] | select(.name | contains("+k0s")) | .name' 2>/dev/null)
+    
+    if [ -z "$k0s_versions" ]; then
+        # k0s artifacts not found in this release - return empty (not an error)
+        echo ""
+        return 0
+    fi
+    
+    # Extract k0s versions from artifact names
+    # Pattern: extract v1.34.4+k0s.0 from "kairos-hadron-v0.0.4-standard-amd64-generic-v4.0.1-k0sv1.34.4+k0s.0.iso"
+    local extracted_versions=$(echo "$k0s_versions" | grep -oE 'k0sv[0-9]+\.[0-9]+\.[0-9]+\+k0s\.[0-9]+' | sed 's/k0s//' | sort -u)
+    
+    if [ -z "$extracted_versions" ]; then
+        echo ""
+        return 0
+    fi
+    
+    # Get the highest semantic version
+    local highest_version=$(echo "$extracted_versions" | sort -V | tail -n1)
+    
+    echo "$highest_version"
+}
+
 get_hadron_version_from_release() {
     local kairos_version="$1"
     local api_url="https://api.github.com/repos/kairos-io/kairos/releases/tags/$kairos_version"
@@ -211,13 +249,20 @@ get_component_versions() {
         return 1
     fi
     
-    # Get K3s and Hadron versions from GitHub release artifacts (kairos_version is required)
+    # Get K3s, k0s, and Hadron versions from GitHub release artifacts (kairos_version is required)
     local k3s_version=""
+    local k0s_version=""
     local hadron_version=""
     if [ -n "$kairos_version" ]; then
         k3s_version=$(get_k3s_version_from_release "$kairos_version")
         if [ $? -ne 0 ]; then
             echo "Error: Failed to get K3s version from release for version $kairos_version" >&2
+            return 1
+        fi
+        
+        k0s_version=$(get_k0s_version_from_release "$kairos_version")
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed to get k0s version from release for version $kairos_version" >&2
             return 1
         fi
         
@@ -227,7 +272,7 @@ get_component_versions() {
             return 1
         fi
     else
-        echo "Error: kairos_version is required to extract K3s and Hadron versions from release" >&2
+        echo "Error: kairos_version is required to extract K3s, k0s, and Hadron versions from release" >&2
         return 1
     fi
     
@@ -239,7 +284,8 @@ get_component_versions() {
   "provider_version": "$provider_version",
   "auroraboot_version": "$auroraboot_version",
   "hadron_version": "$hadron_version",
-  "k3s_version": "$k3s_version"
+  "k3s_version": "$k3s_version",
+  "k0s_version": "$k0s_version"
 }
 EOF
 }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -109,6 +109,65 @@ get_k3s_version_from_release() {
     echo "$highest_version"
 }
 
+# Function to get the latest AuroraBoot release from GitHub API
+# Returns: latest AuroraBoot version tag (e.g., v0.4.5)
+get_latest_auroraboot_version() {
+    local api_url="https://api.github.com/repos/kairos-io/AuroraBoot/releases/latest"
+    local response
+    
+    response=$(curl -s -H "Accept: application/vnd.github.v3+json" "$api_url")
+    
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to fetch latest AuroraBoot release from GitHub API" >&2
+        return 1
+    fi
+    
+    local tag_name=$(echo "$response" | jq -r '.tag_name // empty')
+    
+    if [ -z "$tag_name" ] || [ "$tag_name" = "null" ]; then
+        echo "Error: No tag name found in AuroraBoot API response" >&2
+        return 1
+    fi
+    
+    echo "$tag_name"
+}
+
+# Function to extract Hadron version from GitHub release artifacts
+# Arguments:
+#   $1: kairos_version (e.g., v4.0.3)
+# Returns: Hadron version (e.g., v0.0.4) or empty string on error
+get_hadron_version_from_release() {
+    local kairos_version="$1"
+    local api_url="https://api.github.com/repos/kairos-io/kairos/releases/tags/$kairos_version"
+    local response
+    
+    response=$(curl -s -H "Accept: application/vnd.github.v3+json" "$api_url")
+    
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to fetch release data for version $kairos_version" >&2
+        return 1
+    fi
+    
+    # Extract artifact names that contain "hadron"
+    local hadron_artifacts=$(echo "$response" | jq -r '.assets[] | select(.name | contains("hadron")) | .name' 2>/dev/null)
+    
+    if [ -z "$hadron_artifacts" ]; then
+        echo "Error: No Hadron artifacts found in release $kairos_version" >&2
+        return 1
+    fi
+    
+    # Extract Hadron version from artifact names
+    # Pattern: extract v0.0.4 from "kairos-hadron-v0.0.4-core-amd64-generic-v4.0.3.iso"
+    local extracted_version=$(echo "$hadron_artifacts" | grep -oE 'hadron-v[0-9]+\.[0-9]+\.[0-9]+' | sed 's/hadron-//' | sort -u | head -n1)
+    
+    if [ -z "$extracted_version" ]; then
+        echo "Error: Could not extract Hadron version from artifact names" >&2
+        return 1
+    fi
+    
+    echo "$extracted_version"
+}
+
 # Function to fetch subcomponent versions from kairos-init Makefile and kairos release
 # Arguments:
 #   $1: kairos_init_version (e.g., v0.5.20)
@@ -131,18 +190,32 @@ get_component_versions() {
     local agent_version=$(echo "$response" | grep -E '^AGENT_VERSION\s*:?=' | sed 's/.*:=\s*//' | tr -d '\r\n')
     local immucore_version=$(echo "$response" | grep -E '^IMMUCORE_VERSION\s*:?=' | sed 's/.*:=\s*//' | tr -d '\r\n')
     local provider_version=$(echo "$response" | grep -E '^PROVIDER_KAIROS_VERSION\s*:?=' | sed 's/.*:=\s*//' | tr -d '\r\n')
-    local auroraboot_version=$(echo "$response" | grep -E '^AURORABOOT_VERSION\s*:?=' | sed 's/.*:=\s*//' | tr -d '\r\n')
     
-    # Get K3s version from GitHub release artifacts if kairos_version is provided
+    # Get latest AuroraBoot version from its own releases
+    local auroraboot_version
+    auroraboot_version=$(get_latest_auroraboot_version)
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to get AuroraBoot version" >&2
+        return 1
+    fi
+    
+    # Get K3s and Hadron versions from GitHub release artifacts (kairos_version is required)
     local k3s_version=""
+    local hadron_version=""
     if [ -n "$kairos_version" ]; then
         k3s_version=$(get_k3s_version_from_release "$kairos_version")
         if [ $? -ne 0 ]; then
             echo "Error: Failed to get K3s version from release for version $kairos_version" >&2
             return 1
         fi
+        
+        hadron_version=$(get_hadron_version_from_release "$kairos_version")
+        if [ $? -ne 0 ]; then
+            echo "Error: Failed to get Hadron version from release for version $kairos_version" >&2
+            return 1
+        fi
     else
-        echo "Error: kairos_version is required to extract K3s version from release" >&2
+        echo "Error: kairos_version is required to extract K3s and Hadron versions from release" >&2
         return 1
     fi
     
@@ -153,6 +226,7 @@ get_component_versions() {
   "immucore_version": "$immucore_version",
   "provider_version": "$provider_version",
   "auroraboot_version": "$auroraboot_version",
+  "hadron_version": "$hadron_version",
   "k3s_version": "$k3s_version"
 }
 EOF

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,5 +1,29 @@
 #!/bin/bash
 
+# Helper function for curl with proper error handling and optional auth
+# Uses GH_TOKEN or GITHUB_TOKEN if available for authentication
+_curl_github() {
+    local url="$1"
+    local auth_header=""
+    
+    if [ -n "${GH_TOKEN:-}" ]; then
+        auth_header="Authorization: Bearer $GH_TOKEN"
+    elif [ -n "${GITHUB_TOKEN:-}" ]; then
+        auth_header="Authorization: Bearer $GITHUB_TOKEN"
+    fi
+    
+    if [ -n "$auth_header" ]; then
+        curl -fSs -H "Accept: application/vnd.github.v3+json" -H "$auth_header" "$url"
+    else
+        curl -fSs -H "Accept: application/vnd.github.v3+json" "$url"
+    fi
+}
+
+# Helper function for curl to raw content (no auth needed typically)
+_curl_raw() {
+    curl -fSs "$1"
+}
+
 # Function to fetch all release branches
 # Returns a list of all release branches sorted by version
 fetch_all_releases() {
@@ -16,9 +40,7 @@ get_latest_kairos_release() {
     local api_url="https://api.github.com/repos/kairos-io/kairos/releases/latest"
     local response
     
-    response=$(curl -s -H "Accept: application/vnd.github.v3+json" "$api_url")
-    
-    if [ $? -ne 0 ]; then
+    if ! response=$(_curl_github "$api_url"); then
         echo "Error: Failed to fetch latest release from GitHub API" >&2
         return 1
     fi
@@ -53,9 +75,7 @@ get_kairos_init_version() {
     local dockerfile_url="https://raw.githubusercontent.com/kairos-io/kairos/refs/tags/$version/images/Dockerfile"
     local response
     
-    response=$(curl -s "$dockerfile_url")
-    
-    if [ $? -ne 0 ]; then
+    if ! response=$(_curl_raw "$dockerfile_url"); then
         echo "Error: Failed to fetch Dockerfile for version $version" >&2
         return 1
     fi
@@ -79,9 +99,7 @@ get_k3s_version_from_release() {
     local api_url="https://api.github.com/repos/kairos-io/kairos/releases/tags/$kairos_version"
     local response
     
-    response=$(curl -s -H "Accept: application/vnd.github.v3+json" "$api_url")
-    
-    if [ $? -ne 0 ]; then
+    if ! response=$(_curl_github "$api_url"); then
         echo "Error: Failed to fetch release data for version $kairos_version" >&2
         return 1
     fi
@@ -115,9 +133,7 @@ get_latest_auroraboot_version() {
     local api_url="https://api.github.com/repos/kairos-io/AuroraBoot/releases/latest"
     local response
     
-    response=$(curl -s -H "Accept: application/vnd.github.v3+json" "$api_url")
-    
-    if [ $? -ne 0 ]; then
+    if ! response=$(_curl_github "$api_url"); then
         echo "Error: Failed to fetch latest AuroraBoot release from GitHub API" >&2
         return 1
     fi
@@ -141,9 +157,7 @@ get_hadron_version_from_release() {
     local api_url="https://api.github.com/repos/kairos-io/kairos/releases/tags/$kairos_version"
     local response
     
-    response=$(curl -s -H "Accept: application/vnd.github.v3+json" "$api_url")
-    
-    if [ $? -ne 0 ]; then
+    if ! response=$(_curl_github "$api_url"); then
         echo "Error: Failed to fetch release data for version $kairos_version" >&2
         return 1
     fi
@@ -158,7 +172,7 @@ get_hadron_version_from_release() {
     
     # Extract Hadron version from artifact names
     # Pattern: extract v0.0.4 from "kairos-hadron-v0.0.4-core-amd64-generic-v4.0.3.iso"
-    local extracted_version=$(echo "$hadron_artifacts" | grep -oE 'hadron-v[0-9]+\.[0-9]+\.[0-9]+' | sed 's/hadron-//' | sort -u | head -n1)
+    local extracted_version=$(echo "$hadron_artifacts" | grep -oE 'hadron-v[0-9]+\.[0-9]+\.[0-9]+' | sed 's/hadron-//' | sort -Vu | tail -n1)
     
     if [ -z "$extracted_version" ]; then
         echo "Error: Could not extract Hadron version from artifact names" >&2
@@ -179,9 +193,7 @@ get_component_versions() {
     local makefile_url="https://raw.githubusercontent.com/kairos-io/kairos-init/refs/tags/$kairos_init_version/Makefile"
     local response
     
-    response=$(curl -s "$makefile_url")
-    
-    if [ $? -ne 0 ]; then
+    if ! response=$(_curl_raw "$makefile_url"); then
         echo "Error: Failed to fetch Makefile for kairos-init version $kairos_init_version" >&2
         return 1
     fi


### PR DESCRIPTION
## Summary
- Fetch AuroraBoot version from its own GitHub releases
- Extract Hadron, K3s, and k0s versions from Kairos release artifacts
- Add helper functions for curl with proper error handling and optional auth
- Update workflow with Node.js setup and npm install
- Use dynamic values from docsVersionCustomFields for site customFields

## Version Resolution Chain
| Component | Source |
|-----------|--------|
| Kairos | Latest release from `kairos-io/kairos` or `--version` flag |
| KAIROS_INIT | From Kairos Dockerfile (`ARG KAIROS_INIT=`) |
| Agent | From kairos-init Makefile (`AGENT_VERSION`) |
| Provider | From kairos-init Makefile (`PROVIDER_KAIROS_VERSION`) |
| Immucore | From kairos-init Makefile (`IMMUCORE_VERSION`) |
| Hadron | From Kairos release artifacts (e.g., `kairos-hadron-v0.0.4-...`) |
| K3s | From Kairos release artifacts (highest version found) |
| k0s | From Kairos release artifacts (if present, else template) |
| AuroraBoot | Latest release from `kairos-io/AuroraBoot` |

## Test plan
- [x] Dry-run test for v4.0.3 passes locally (no k0s artifacts)
- [x] Dry-run test for v4.0.1 passes locally (has k0s artifacts)
- [ ] Manual workflow trigger with dry_run=true
- [ ] Manual workflow trigger for specific version

Made with [Cursor](https://cursor.com)