### PR TITLE
fix: use v401FlavorOptions for v4.0.3

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -86,7 +86,7 @@ const v372FlavorOptions = [
   {family: 'hadron', flavor: 'hadron', flavorRelease: '0.0.1', label: 'Hadron 0.0.1'},
 ] as const;
 
-const v401FlavorOptions = [
+const hadronFlavorOptions = [
   {family: 'hadron', flavor: 'hadron', flavorRelease: 'v0.0.4', label: 'Hadron v0.0.4'},
 ] as const;
 
@@ -96,7 +96,7 @@ const docsVersionCustomFields = {
     hadronFlavorRelease: 'v0.0.4',
     k3sVersion: 'v1.35.2+k3s1',
     k0sVersion: 'v1.34.3+k0s.0',
-    flavorOptions: v372FlavorOptions,
+    flavorOptions: hadronFlavorOptions,
     providerVersion: 'v2.14.2',
     auroraBootVersion: 'v0.20.0',
     kairosInitVersion: 'v0.8.4',


### PR DESCRIPTION
## Summary
Fix validation failure by using the correct flavor options for v4.0.3.

v4.0.3 is a Hadron-only release, so it should use `v401FlavorOptions` (which contains only Hadron v0.0.4), not `v372FlavorOptions` (which contains legacy multi-distro flavors).

## Test
```
npm run validate:release-artifacts

[v4.0.3] OK (1 flavor options validated)
[v3.7.2] OK (10 flavor options validated)
[v3.6.0] OK (9 flavor options validated)
All selected versions validated successfully.
```

Made with [Cursor](https://cursor.com)