### PR TITLE
fix: treat no-changes-needed as success in release automation

### DIFF
--- a/scripts/release-automation.sh
+++ b/scripts/release-automation.sh
@@ -523,12 +523,13 @@ commit_push_and_open_pr() {
         return 0
     fi
 
-    if git diff --quiet && git diff --cached --quiet; then
-        log "INFO" "No changes detected after processing $version"
+    git add versions.json docusaurus.config.ts versioned_docs versioned_sidebars
+
+    if git diff --cached --quiet; then
+        log "INFO" "No changes to commit for $version - docs already up to date"
         return 0
     fi
 
-    git add versions.json docusaurus.config.ts versioned_docs versioned_sidebars
     git commit -m "chore: update docs versions for $version"
 
     if [ "$PUSH_CHANGES" = false ]; then


### PR DESCRIPTION
## Summary
- Fix release automation to treat "docs already up to date" as success, not failure
- Stage relevant files first, then check if there are staged changes to commit

## Problem
When the release monitor runs and docs are already up to date for the latest version, the workflow was failing with exit code 1. This happened because:

1. `git diff --quiet` checked for *any* uncommitted changes (including unrelated files)
2. If unrelated files were modified, the script would try to commit
3. But `git add` only staged specific doc files, which had no changes
4. `git commit` failed because nothing was staged

Example: https://github.com/kairos-io/kairos-docs/actions/runs/24880739896/job/72848210217

## Solution
Reorder the logic to:
1. First stage the relevant files (`git add`)
2. Then check if there are any staged changes (`git diff --cached --quiet`)
3. If nothing is staged, return success with a clear message
4. Only attempt to commit if there are actually staged changes

This ensures unrelated file modifications don't cause false failures when docs are already current.

Made with [Cursor](https://cursor.com)