### PR TITLE
fix: replace HTML comments with MDX comments in blog posts

### DIFF
--- a/blog/2023-01-27-release-v1.5.md
+++ b/blog/2023-01-27-release-v1.5.md
@@ -19,7 +19,7 @@ title: Kairos release v1.5
 
 We are thrilled to announce the release of Kairos version 1.5, a major update that brings significant improvements to user experience and security. With this release, we have made it even easier for you to install and set up Kairos, as well as better protect your user data. Our community has been an invaluable source of feedback, bug reports, and contributions, and we are grateful for their support.
 
-<!--truncate-->
+{/* truncate */}
 
 You can find Kairos core images at https://github.com/kairos-io/kairos/releases/tag/v1.5.0 and images with k3s pre-bundled here: https://github.com/kairos-io/provider-kairos/releases/tag/v1.5.1. 
 

--- a/blog/2023-02-07-Kairos-at-FOSDEM-2023.md
+++ b/blog/2023-02-07-Kairos-at-FOSDEM-2023.md
@@ -11,7 +11,7 @@ title: Kairos at FOSDEM 2023
 
 I recently had the opportunity to attend FOSDEM 2023 and share a bit about the Kairos project. In this post I want to summarize what I presented and share other interesting presentations I attended, which I believe are relevant for Kairos and our community.
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## How we build and maintain Kairos

--- a/blog/2023-02-26-release-v1.6.md
+++ b/blog/2023-02-26-release-v1.6.md
@@ -19,7 +19,7 @@ title: Kairos release v1.6
 
 Kairos is a cloud-native meta-Linux distribution that brings the power of public cloud to your on-premises environment. With Kairos, you can build your own cloud with complete control and no vendor lock-in. It allows you to easily spin up a Kubernetes cluster with the Linux distribution of your choice, and manage the entire cluster lifecycle with Kubernetes.
 
-<!--truncate-->
+{/* truncate */}
 
 #### Why you should try Kairos:
 Kairos provides a wide range of use cases, from Kubernetes applications to appliances and more. You can provision nodes with your own image or use Kairos releases for added flexibility. Kairos also simplifies day-2 operations like node upgrades. It provides the benefits of a unified, cloud-native approach to OS management.

--- a/blog/2023-03-09-Kairos-at-the-KCD-Amsterdam-and-Paris-2023.md
+++ b/blog/2023-03-09-Kairos-at-the-KCD-Amsterdam-and-Paris-2023.md
@@ -11,7 +11,7 @@ title: Kairos at the KCD Amsterdam and Paris 2023
 
 We recently had the opportunity to sponsor two Kubernetes events, [KCD Amsterdam][amsterdam] and [KCD Paris][paris]. This blog post, is a summary about my personal experience attending them.
 
-<!--truncate-->
+{/* truncate */}
 
 Let me start by saying, that I'm fairly new to Kubernetes and its community :wave:. I know this project is big and that there are many companies building products and services around it, or have an interest in adopting it. So, I was very curious to see what kind of people I was going to meet and understand how Kairos could help them.
 

--- a/blog/2023-03-13-kairos-canonical.md
+++ b/blog/2023-03-13-kairos-canonical.md
@@ -19,7 +19,7 @@ Hello Kairos community!
 
 We are thrilled to announce that **Kairos** has been used as a key building block for a revolutionary Telco Radio Edge solution developed in collaboration with [Spectro Cloud](https://www.spectrocloud.com/) and [Canonical](https://canonical.com/). This cutting-edge solution showcases the latest advances in OpenRAN automation and distributed compute management, and took center stage at this year's Mobile World Congress.
 
-<!--truncate-->
+{/* truncate */}
 
 The Telco Radio Edge solution leverages the power of Kairos, Ubuntu Pro 22.04 LTS with RT kernel, and MicroK8s CAPI provider to deliver highly distributed edge node onboarding, secure deployment, and substrate provisioning. With this innovative technology stack, we’ve enabled OpenRAN o-DU service orchestration at scale, while optimizing performance, scalability, reliability, and security.
 

--- a/blog/2023-03-22-understanding-immutability.md
+++ b/blog/2023-03-22-understanding-immutability.md
@@ -18,7 +18,7 @@ title: 'Understanding Immutable Linux OS: Benefits, Architecture, and Challenges
 
 :::
 
-<!--truncate-->
+{/* truncate */}
 
 
 For years, the traditional Linux operating system has been a top pick for its flexibility and ability to be customized. But as great as it is, there are use cases in which stricter security rules and higher reliability standards are needed. That's where immutable Linux operating systems come in - offering a more secure and reliable option, especially in settings where security is paramount.

--- a/blog/2023-03-29-home-lab-with-kairos-and-wireguard.md
+++ b/blog/2023-03-29-home-lab-with-kairos-and-wireguard.md
@@ -14,7 +14,7 @@ title: Access your home-lab Kairos cluster over a Wireguard VPN
 You got yourself a Raspberry Pi (or more), and you want to put them to good use.
 You decide to make a Kubernetes cluster out of them, so that you can utilise the resources better, use familiar tools and implement infrastructure-as-code.
 
-<!--truncate-->
+{/* truncate */}
 
 
 Up to this point, kudos to you for demanding no less than a real cloud from your home infra.

--- a/blog/2023-04-13-release-v2.0.md
+++ b/blog/2023-04-13-release-v2.0.md
@@ -19,7 +19,7 @@ title: Kairos release v2.0
 
 Kairos is a cloud-native meta-Linux distribution that brings the power of public cloud to your on-premises environment. With Kairos, you can build your own cloud with complete control and no vendor lock-in. It allows you to easily spin up a Kubernetes cluster with the Linux distribution of your choice, and manage the entire cluster lifecycle with Kubernetes.
 
-<!--truncate-->
+{/* truncate */}
 
 
 #### Why you should try Kairos:

--- a/blog/2023-04-18-sena-architecture.md
+++ b/blog/2023-04-18-sena-architecture.md
@@ -17,7 +17,7 @@ title: Kairos is now part of the Secure Edge-Native Architecture by Spectro Clou
 
 The Kairos team is thrilled to announce the release of the Secure Edge-Native Architecture (SENA) whitepaper! You can download it [here](https://github.com/kairos-io/kairos/files/11250843/Secure-Edge-Native-Architecture-white-paper-20240417.3.pdf)
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## What is SENA?

--- a/blog/2023-06-15-release-v2.2.md
+++ b/blog/2023-06-15-release-v2.2.md
@@ -19,7 +19,7 @@ title: Kairos release v2.2
 
 Kairos is a cloud-native meta-Linux distribution that brings the power of public cloud to your on-premises environment. With Kairos, you can build your own cloud with complete control and no vendor lock-in. It allows you to easily spin up a Kubernetes cluster with the Linux distribution of your choice, and manage the entire cluster lifecycle with Kubernetes.
 
-<!--truncate-->
+{/* truncate */}
 
 
 #### Why you should try Kairos:

--- a/blog/2023-07-10-release-v2.3.md
+++ b/blog/2023-07-10-release-v2.3.md
@@ -19,7 +19,7 @@ title: Unveiling Kairos v2.3 - FIPS Compliance and More!
 
 We're excited to roll out Kairos v2.3, the latest iteration of our project, packed with new features and enhancements. The most notable change in this version is the support for Federal Information Processing Standards (FIPS).
 
-<!--truncate-->
+{/* truncate */}
 
 
 FIPS, a set of standards governing document processing, encryption algorithms, and other IT standards for non-military government agencies and contractors, is now an integral part of Kairos. The addition of a FIPS generic and Ubuntu-specific framework image marks a significant milestone in our journey to offer a secure and reliable Linux distribution. We made sure to included examples to facilitate building FIPS from scratch on Ubuntu, Fedora, and RockyLinux.

--- a/blog/2023-09-19-release-v2.4.md
+++ b/blog/2023-09-19-release-v2.4.md
@@ -19,7 +19,7 @@ title: Kairos release v2.4
 
 We're thrilled to announce the release of version 2.4.0 of Kairos which brings a wealth of exciting improvements and essential bug fixes that we can't wait to share with you.
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## Enhanced Release Artifacts Naming

--- a/blog/2023-09-26-hacktoberfest-2023.md
+++ b/blog/2023-09-26-hacktoberfest-2023.md
@@ -12,7 +12,7 @@ title: Hacktoberfest 2023
 Hacktoberfest 2023 is here, and we are excited to announce that Kairos is taking part by creating some good first issues
 for new contributors to get started with and also by hosting a Hacktoberfest event on October 19th in Brussels.
 
-<!--truncate-->
+{/* truncate */}
 
 ## Why is Hacktoberfest important to us?
 

--- a/blog/2023-11-14-release-v2.4.2.md
+++ b/blog/2023-11-14-release-v2.4.2.md
@@ -22,7 +22,7 @@ This Kairos release was a similar case. We didn't introduce any breaking changes
 
 The detailed list of changes can be found in the [release notes](https://github.com/kairos-io/kairos/releases/tag/v2.4.2) but the most important things to notice are listed below.
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## New artifact names

--- a/blog/2024-01-11-release-v2.5.md
+++ b/blog/2024-01-11-release-v2.5.md
@@ -25,7 +25,7 @@ We start the year with the release of Kairos v2.5.0. This time, we focused on th
 1. **Improving the Kairos Factory user experience**: On previous releases we shared how our artifact names have changed to make it easier to distinguish between them. In this release we worked on Versioneer, a component that helps build such names in more sofisticated ways than the original script did. This has been aggregated to the `kairos-agent upgrade` command to help you filter through upgradable versions.
 2. **Adding support for UKI (Unified Kernel Images)**: This is still a WIP but we already have a proof of concept, meaning that Kairos will increase its security level by validating signatures using the EFI bootloader.
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## Known Issues

--- a/blog/2024-02-06-Kairos-at-FOSDEM-2024.md
+++ b/blog/2024-02-06-Kairos-at-FOSDEM-2024.md
@@ -11,7 +11,7 @@ title: Kairos at FOSDEM 2024
 
 Last year [I said](/blog/2023/02/07/kairos-at-fosdem-2023/) you could expect Kairos to engage further during FOSDEM. And I'm quite pleased to say that's exactly what we did! As part of the open-source ecosystem, we recognize the importance of participating in these types of events. We do so, because we understand how critical it is to go where our users are, but this year we went a bit further and we also reached out to other similar projects.
 
-<!--truncate-->
+{/* truncate */}
 
 ## From Free-Lunch to Dog-Fooding: A Culinary Journey in Crafting IaC for Kairos Testing and Building
 

--- a/blog/2024-03-08-release-v3.md
+++ b/blog/2024-03-08-release-v3.md
@@ -19,7 +19,7 @@ title: Kairos release v3
 
 The team is very excited to announce the next major release of Kairos, Kairos v3! This release marks a major milestone in our [roadmap](https://github.com/orgs/kairos-io/projects/2/views/1) by adding support for Unified Kernel Images (UKI). This will enhance the level of security that you can achieve on your system with the help of Trusted Boot.
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## Trusted Boot

--- a/blog/2024-03-26-spos-panel-at-kubecon-paris-2024.md
+++ b/blog/2024-03-26-spos-panel-at-kubecon-paris-2024.md
@@ -11,7 +11,7 @@ title: SPOS Panel at KubeCon Paris 2024
 
 I recently had the opportunity to attend KubeCon 2024. You can find my recap at the [Spectro Cloud Blog](https://www.spectrocloud.com/blog/kubecon-paris-edge-ai-and-la-vie-en-cloud-native), but I'd like to add some additional information about the Special Purpose Operating System Panel in which we participated.
 
-<!--truncate-->
+{/* truncate */}
 
 
 The panel was scheduled for the last day of KubeCon, which I think probably hurt the attendance since many people had already left. Nevertheless, according to the scheduling tool, 351 people were planning to attend.

--- a/blog/2024-04-02-xz-backdoor.md
+++ b/blog/2024-04-02-xz-backdoor.md
@@ -15,7 +15,7 @@ It's all over the tech news. Someone managed to put a backdoor on xz Utils, a ve
 
 A backdoor that can be used to exploit systemd based Linux via ssh was introduced in xz Utils. Only Kairos Tumbleweed v3.0.1 and v3.0.2 were affected. We deleted all related OCI images from our repos and artifacts from our releases. If you installed it and the system was exposed to the internet, you should do a complete re-install. If you hosted security keys in given system, you should rotate them.
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## xz Utils Backdoor

--- a/blog/2024-04-10-trusted-boot.md
+++ b/blog/2024-04-10-trusted-boot.md
@@ -13,7 +13,7 @@ title: 'Unlocking the Mysteries of Trusted Boot: A Deep Dive into Secure System 
 
 In the evolving landscape of cybersecurity, protecting the integrity of computing systems from the moment they power on has become very important. As threats become more sophisticated, understanding and implementing advanced boot security mechanisms like Trusted Boot, Full Disk Encryption (FDE), Secure Boot, and Measured Boot are critical for safeguarding data and ensuring system integrity. This article demystifies these concepts, explores their significance, and examines their implementation in modern computing environments, particularly focusing on the Linux ecosystem and the approaches within the Kairos project.
 
-<!--truncate-->
+{/* truncate */}
 
 
 > We are facing new challenges as 2024 starts. While AI is pushing innovating technologies to the edge, security becomes even more critical for organizations to protect sensitive data.

--- a/blog/2024-07-11-release-v3.1.md
+++ b/blog/2024-07-11-release-v3.1.md
@@ -19,7 +19,7 @@ title: Kairos release v3.1
 
 We are thrilled to announce the release of Kairos v3.1.0! This update brings a host of significant enhancements to further secure and streamline your edge computing environment.
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## Key Features and Updates

--- a/blog/2024-07-19-release-v3.1.1.md
+++ b/blog/2024-07-19-release-v3.1.1.md
@@ -20,7 +20,7 @@ title: Kairos release v3.1.1
 We are thrilled to announce the release of Kairos v3.1.1! This patch release is a bugfix and security release.
 
 
-<!--truncate-->
+{/* truncate */}
 
 ## Key Features and Updates
 

--- a/blog/2024-07-22-crowdstrike-outage.md
+++ b/blog/2024-07-22-crowdstrike-outage.md
@@ -16,7 +16,7 @@ The recent CrowdStrike update fiasco that wreaked havoc across industries, causi
 
 CrowdStrike's faulty update led to massive system crashes. Kairos's immutable and decentralized architecture offers a robust alternative, ensuring system integrity and swift recovery in such scenarios.
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## CrowdStrike Update: What Went Wrong

--- a/blog/2024-08-13-hackweek-2024.md
+++ b/blog/2024-08-13-hackweek-2024.md
@@ -16,7 +16,7 @@ Over the course of the week, we set aside our usual tasks to focus entirely on t
 
 During the first day we got together to brainstorm. Many good ideas came from each of us on what to work on. It lifts my spirit to see that our project while very stable, still has lots of avenues to explore and that everyone in our team is keen on making Kairos a better project.
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## Kairos Kiosk & Quiz App by Dimitris

--- a/blog/2024-10-08-cncf-sandbox-project.md
+++ b/blog/2024-10-08-cncf-sandbox-project.md
@@ -13,7 +13,7 @@ We’re thrilled to announce that since April 2024, Kairos has been officially p
 
 You might be wondering - what does being part of the CNCF mean for you? The CNCF is known for backing the most innovative, reliable, and secure projects in the cloud-native space, and having their support brings a number of crucial benefits. Let’s dive into why this matters.
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## Stability and Long-Term Support

--- a/blog/2025-03-18-how-i-automated-my-doorbell-with-kairos-and-you-can-too/index.md
+++ b/blog/2025-03-18-how-i-automated-my-doorbell-with-kairos-and-you-can-too/index.md
@@ -11,7 +11,7 @@ title: How I Automated My Doorbell with Kairos (and You Can Too)
 
 Picture this: You’re deep in focus, coding away, and the doorbell rings. Except… you never hear it. The mailman leaves, and now your package is on an adventure you didn't plan for. That’s exactly what happened to me, so I did what any geek would do—turn my dumb doorbell into a smart one using Kairos.
 
-<!--truncate-->
+{/* truncate */}
 
 
 :::warning Disclaimer

--- a/blog/2025-03-26-kairos-init-announcement.md
+++ b/blog/2025-03-26-kairos-init-announcement.md
@@ -24,7 +24,7 @@ In this post, we’ll take you behind the scenes:
 
 This is the story of how we rebuilt the foundation of Kairos, one layer at a time.
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## 🐳 The Early Days: Building with Dockerfiles

--- a/blog/2025-04-02-kairos-meets-k0s.md
+++ b/blog/2025-04-02-kairos-meets-k0s.md
@@ -17,7 +17,7 @@ Then there’s the [`provider-kairos`](https://github.com/kairos-io/provider-kai
 
 That is... until now.
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## Enter k0s: The Zero Friction Kubernetes

--- a/blog/2025-04-15-system-extensions.md
+++ b/blog/2025-04-15-system-extensions.md
@@ -17,7 +17,7 @@ Today, we’re introducing a much cleaner answer: **the new system extension man
 
 ---
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## 💡 What's New

--- a/blog/2025-04-24-release-v3.4.0.md
+++ b/blog/2025-04-24-release-v3.4.0.md
@@ -26,7 +26,7 @@ In the last few months, we’ve been heads-down rethinking what makes Kairos pow
 
 Let’s walk through the biggest milestones in Kairos 3.4.0, how they work, and why they matter.
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## 🛠️ Rebuilding Kairos from the Ground Up with `kairos-init`

--- a/blog/2025-07-25-release-v3.5.0.md
+++ b/blog/2025-07-25-release-v3.5.0.md
@@ -21,7 +21,7 @@ title: Kairos release v3.5.0
 
 We're excited to announce the release of Kairos 3.5.0! This release represents a significant milestone for the broader Kairos ecosystem, marking the completion of several key features across multiple projects that work together to improve the overall Kairos experience.
 
-<!--truncate-->
+{/* truncate */}
 
 
 ## ⚙️ Meet the Kairos Operator

--- a/blog/2025-08-08-commercial-support-by-spectro-cloud.md
+++ b/blog/2025-08-08-commercial-support-by-spectro-cloud.md
@@ -18,7 +18,7 @@ Today, we're excited to share a new milestone in that journey:
 
 Before we dive into what that means, let's take a step back and talk about what makes an open-source project *reliable*—especially when the stakes are high.
 
-<!--truncate-->
+{/* truncate */}
 
 
 ---

--- a/blog/2026-02-27-kairos-release-v4.0.0.md
+++ b/blog/2026-02-27-kairos-release-v4.0.0.md
@@ -20,7 +20,7 @@ At the same time, distro flexibility remains core to Kairos. This is visible in 
 
 For additional migration and build context, read [Hadron-Only Artifacts with Ongoing Distro Support](/blog/2026/02/25/kairos-v4-hadron-artifacts-and-distro-flexibility/).
 
-<!--truncate-->
+{/* truncate */}
 
 ## What v4 delivers in practice
 


### PR DESCRIPTION
## Summary
- Replace `<!--truncate-->` with `{/* truncate */}` in all blog posts
- Fixes MDX v3 compatibility issue where HTML comments are treated as JSX

## Context
The Release Monitor CI workflow was failing because MDX v3 (used in Docusaurus 3.x) doesn't support HTML comments. The `<!--truncate-->` pattern caused build errors like:

```
Unexpected character `!` (U+0021) before name, expected a character that can start a name
```

## Test plan
- [x] `npm run build` passes locally

Made with [Cursor](https://cursor.com)