### PR TITLE
fix: sync build files from main in release automation

### DIFF
--- a/scripts/release-automation.sh
+++ b/scripts/release-automation.sh
@@ -188,6 +188,18 @@ ensure_release_branch() {
     log "INFO" "Using branch $branch_name"
 }
 
+sync_build_files_from_main() {
+    if [ "$DRY_RUN" = true ]; then
+        log "INFO" "[DRY RUN] Would sync build files, config, and blog from main"
+        return 0
+    fi
+
+    log "INFO" "Syncing build configuration files, docusaurus config, and blog from main branch"
+    git checkout origin/main -- package.json package-lock.json docusaurus.config.ts blog/
+    npm ci
+    log "INFO" "Build files synced and dependencies installed"
+}
+
 create_docs_version_if_missing() {
     local version="$1"
     if [ -d "versioned_docs/version-$version" ]; then
@@ -590,6 +602,7 @@ process_version() {
     log "INFO" "Retention keep list (latest patch of last 3 major.minor): $(format_csv "${KEEP_VERSIONS[@]}")"
 
     ensure_release_branch "$version"
+    sync_build_files_from_main
 
     local kairos_init_version
     kairos_init_version=$(get_kairos_init_version "$version")


### PR DESCRIPTION
## Summary
- Sync `package.json`, `package-lock.json`, `docusaurus.config.ts`, and `blog/` from main before building on release branches
- Fixes Release Monitor CI failures caused by outdated dependencies or MDX syntax issues on release branches

## Context
Release branches can have outdated files which cause build failures when:
1. Node.js or Docusaurus versions are updated on main (incompatible `package.json`)
2. Blog posts use HTML comments that aren't MDX-compatible (different `blog/` content)
3. MDX configuration differs between branches (`docusaurus.config.ts` has different `future.v4` settings)

By syncing these files from main before running `npm ci` and the build, we ensure the release automation uses the latest working configuration.

## Test plan
- [x] Tested locally with `./scripts/release-automation.sh --version v4.0.3 --push=false --verbose`
- [x] Build passes after syncing files from main

Made with [Cursor](https://cursor.com)