### PR TITLE
docs: Clarify partitioning instructions in configuration

### DIFF
--- a/docs/advanced/configuring_partitions.md
+++ b/docs/advanced/configuring_partitions.md
@@ -71,7 +71,8 @@ install:
 
 Note that there are some caveats in the `extra partitions` setup:
  - Only `size`, `fs`, `name` and `label` are used for the partition creation, the name is currently used for the partition label.
- - If a partition has no fs set, the partition will be created, but it will not be formatted.
+ - If `fs` is not set for an extra partition, it defaults to `ext2`.
+ - If a partition should be created without formatting, set `fs` to `none`.
  - No mounting of any type is done during installation to the extra partitions. That part should be done on the stages of the cloud-config manually, with something like the following step:
 
 ```yaml
@@ -81,9 +82,6 @@ Note that there are some caveats in the `extra partitions` setup:
         - mkdir -p /opt/extra
         - mount -o rw /dev/disk/by-label/PARTITION_TWO /opt/extra
 ```
-
-If not filesystem is wanted for a given partitions, the `fs` field whould be set to `none`, otherwise it will interpreted as an error and the installation will fail.
-
 
 ## Manual partitioning
 

--- a/docs/advanced/configuring_partitions.md
+++ b/docs/advanced/configuring_partitions.md
@@ -82,6 +82,9 @@ Note that there are some caveats in the `extra partitions` setup:
         - mount -o rw /dev/disk/by-label/PARTITION_TWO /opt/extra
 ```
 
+If not filesystem is wanted for a given partitions, the `fs` field whould be set to `none`, otherwise it will interpreted as an error and the installation will fail.
+
+
 ## Manual partitioning
 
 In some cases, it's desired that the user has full control over the partitioning of the disk.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -100,7 +100,8 @@ install:
   # extra partitions to create during install
   # only size, label and fs are used
   # name is used for the partition label, but it's not really used during the kairos lifecycle. No spaces allowed.
-  # if no partitioning is wanted, set the fs to "none" and it will be created but not formatted
+  # if fs is not set, it defaults to "ext2"
+  # if a partition should be created but not formatted, set fs to "none"
   # These partitions are not automounted only created and formatted
   extra-partitions:
     - name: myPartition

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -100,7 +100,7 @@ install:
   # extra partitions to create during install
   # only size, label and fs are used
   # name is used for the partition label, but it's not really used during the kairos lifecycle. No spaces allowed.
-  # if no fs is given the partition will be created but not formatted
+  # if no partitioning is wanted, set the fs to "none" and it will be created but not formatted
   # These partitions are not automounted only created and formatted
   extra-partitions:
     - name: myPartition


### PR DESCRIPTION
- Updated instructions to specify that setting `fs` to "none" will create a partition without formatting.
- Added note to prevent installation errors when no filesystem is desired for a partition.