### PR TITLE
fix: point v4.1.1 flavorOptions at Hadron v0.3.0

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -94,13 +94,17 @@ const hadronFlavorOptionsV410 = [
   {family: 'hadron', flavor: 'hadron', flavorRelease: 'v0.2.0', label: 'Hadron v0.2.0'},
 ] as const;
 
+const hadronFlavorOptionsV411 = [
+  {family: 'hadron', flavor: 'hadron', flavorRelease: 'v0.3.0', label: 'Hadron v0.3.0'},
+] as const;
+
 const docsVersionCustomFields = {
   'v4.1.1': {
     registryURL: 'quay.io/kairos',
     hadronFlavorRelease: 'v0.3.0',
     k3sVersion: 'v1.36.1+k3s1',
     k0sVersion: 'v1.36.1+k0s.0',
-    flavorOptions: hadronFlavorOptionsV403,
+    flavorOptions: hadronFlavorOptionsV411,
     providerVersion: 'v2.16.1',
     auroraBootVersion: 'v0.23.0',
     kairosInitVersion: 'v0.14.6',


### PR DESCRIPTION
The v4.1.1 release config set hadronFlavorRelease to v0.3.0 but left flavorOptions referencing hadronFlavorOptionsV403, which lists Hadron v0.0.4. The validate:release-artifacts check builds expected artifact names from flavorOptions[].flavorRelease, so it looked for a non-existent kairos-hadron-v0.0.4-...-v4.1.1 artifact and failed.

Add hadronFlavorOptionsV411 (Hadron v0.3.0) and point v4.1.1 at it, matching the actual published artifacts.