### PR TITLE
docs: document layout plugin init_disk, disk_name and bootable fields

### DIFF
--- a/docs/advanced/multi-disk-dynamic-partitioning.md
+++ b/docs/advanced/multi-disk-dynamic-partitioning.md
@@ -209,10 +209,11 @@ vdb    253:16   0   30G  0 disk
   `pick-disk.sh` is called once per block. For a script with side effects or significant
   latency, consider caching the result in a file and reading from it instead.
 - This example uses UEFI. For legacy BIOS the EFI partition must be replaced with a
-  BIOS boot partition (GPT type `EF02`), which requires a `commands` block using
-  `parted` and `sgdisk` since the layout plugin does not support setting partition type
-  codes. See [Configuring partitions](/docs/advanced/configuring_partitions) for the
-  BIOS variant.
+  BIOS boot partition. You can create one directly with the `layout` plugin by adding a
+  small `ext*` partition with `bootable: true`, which sets the GPT BIOS Boot type for
+  you (see the [`layout` stage module reference](/docs/reference/stage_modules#layout)
+  for the `bootable` flag). The `COS_GRUB` partition above can likewise be marked
+  `bootable: true` to make it a proper EFI System Partition.
 - The `small`/`large` selection is based purely on disk size in bytes. If two disks
   have the same size the result is deterministic but arbitrary — add more specific
   logic to `pick-disk.sh` if your hardware requires it.

--- a/docs/reference/stage_modules.md
+++ b/docs/reference/stage_modules.md
@@ -485,20 +485,23 @@ Each entry under `add_partitions` describes one partition to create in the free 
 | `bootable` | When `true`, marks the partition as bootable and sets its GPT partition type accordingly: a `vfat`/`fat` partition becomes an **EFI System Partition** (for UEFI boot), while an `ext*`/`xfs`/`btrfs` partition becomes a **BIOS Boot** partition (for legacy BIOS boot). Only one partition per device may be marked bootable. |
 
 :::tip Creating boot partitions without `parted`/`sgdisk`
-Because `bootable: true` sets the correct GPT type code, you can create both EFI System Partitions and BIOS Boot partitions with the `layout` plugin alone, without falling back to a `commands` block that calls `parted` or `sgdisk`.
+Because `bootable: true` sets the correct GPT type code, you can create either an **EFI System Partition** (for `vfat`/`fat`) or a **BIOS Boot** partition (for `ext*`/`xfs`/`btrfs`) with the `layout` plugin alone, without falling back to a `commands` block that calls `parted` or `sgdisk`.
 
 ```yaml
 add_partitions:
+  # Choose ONE boot partition per device:
+
   # UEFI: an EFI System Partition
   - fsLabel: COS_GRUB
     pLabel: efi
     size: 64
     filesystem: vfat
     bootable: true
-  # Legacy BIOS: a BIOS Boot partition
-  - pLabel: bios
-    size: 1
-    filesystem: ext4
-    bootable: true
+
+  # Legacy BIOS: replace the ESP above with a BIOS Boot partition
+  # - pLabel: bios
+  #   size: 1
+  #   filesystem: ext4
+  #   bootable: true
 ```
 :::

--- a/docs/reference/stage_modules.md
+++ b/docs/reference/stage_modules.md
@@ -460,3 +460,45 @@ stages:
           size: 25000
           filesystem: "ext4"
 ```
+
+#### `device` options
+
+The `device` block selects the disk the plugin operates on and, optionally, initializes it.
+
+| Field | Description |
+|---|---|
+| `path` | Path to the block device, for example `/dev/sda`. Also accepts a `script:///path/to/script.sh [args...]` value: everything after the `script://` prefix is run as a command and its stdout is used as the device path at runtime. Quote the whole YAML value when it contains spaces or arguments. |
+| `label` | Selects the device by the filesystem label or partition label of a partition it contains, instead of by `path`. When both `label` and `path` are set, the label match takes precedence. |
+| `init_disk` | When `true`, wipes the device and creates a fresh GPT partition table before adding any partitions. Requires `path` to be set, and `label` must be omitted (initializing a disk selected by label is not allowed). Use this to partition a brand-new, empty disk from scratch. |
+| `disk_name` | Only used together with `init_disk`. The plugin derives a deterministic disk GUID from this name, so re-running the same config always produces the same GUID. Defaults to `YIP_DISK` when omitted. |
+
+#### `add_partitions` options
+
+Each entry under `add_partitions` describes one partition to create in the free space of the device:
+
+| Field | Description |
+|---|---|
+| `fsLabel` | Filesystem label applied when the partition is formatted. For XFS this is limited to 12 characters. |
+| `pLabel` | GPT partition label (the partition name). No label is applied if omitted. |
+| `size` | Size in MiB. `size: 0` means "use all remaining free space" and is only valid for the last partition. |
+| `filesystem` | Filesystem to create. Supported values: `ext2` (the default if omitted), `ext3`, `ext4`, `xfs`, `btrfs`, `vfat`/`fat`/`fat16`/`fat32`, and `swap`. Use `none` (or `-`) to create the partition without formatting it. |
+| `bootable` | When `true`, marks the partition as bootable and sets its GPT partition type accordingly: a `vfat`/`fat` partition becomes an **EFI System Partition** (for UEFI boot), while an `ext*`/`xfs`/`btrfs` partition becomes a **BIOS Boot** partition (for legacy BIOS boot). Only one partition per device may be marked bootable. |
+
+:::tip Creating boot partitions without `parted`/`sgdisk`
+Because `bootable: true` sets the correct GPT type code, you can create both EFI System Partitions and BIOS Boot partitions with the `layout` plugin alone, without falling back to a `commands` block that calls `parted` or `sgdisk`.
+
+```yaml
+add_partitions:
+  # UEFI: an EFI System Partition
+  - fsLabel: COS_GRUB
+    pLabel: efi
+    size: 64
+    filesystem: vfat
+    bootable: true
+  # Legacy BIOS: a BIOS Boot partition
+  - pLabel: bios
+    size: 1
+    filesystem: ext4
+    bootable: true
+```
+:::


### PR DESCRIPTION
Closes the documentation gap for the yip layout plugin (yip#240). The reference now describes every `device` and `add_partitions` field, including the `init_disk`/`disk_name` disk-initialization options and the `bootable` flag, which sets the GPT partition type (EFI System Partition for FAT, BIOS Boot for ext/xfs/btrfs).

Also corrects the multi-disk page note that claimed the layout plugin cannot set partition type codes; `bootable: true` now handles this, so a `parted`/`sgdisk` fallback is no longer required for boot partitions.

Refs: kairos-io/kairos#3796