### PR TITLE
Enhance Secure Boot key instructions in trustedboot.mdx

### DIFF
--- a/docs/installation/trustedboot.mdx
+++ b/docs/installation/trustedboot.mdx
@@ -231,6 +231,7 @@ docker run -ti --rm -v /run/pcscd:/run/pcscd -v $PWD/build:/result -v $PWD/keys/
 :::warning Warning
 Notice that for this to work you need to have the `pcscd` service running in your system, and the hardware key must be connected to the system.
 The command mounts the `/run/pcscd` directory to the container, so that the container can access the hardware key.
+Using a pkcs11 URL with `--tpm-pcr-private-key` requires AuroraBoot v0.25.0 or newer.
 :::
 For more info about pkcs11 urls, see the [RFC 7512](https://www.rfc-editor.org/rfc/rfc7512.html) which describes the format of the pkcs11 urls.
 

--- a/docs/installation/trustedboot.mdx
+++ b/docs/installation/trustedboot.mdx
@@ -222,7 +222,7 @@ The .auth format in Secure Boot refers to EFI Signature Lists (ESLs) wrapped in 
 :::
 For a more secure process you can use a hardware key to generate and sign the certificate and sign the EFI files, so you dont need to keep the private key in the filesystem.
 
-To do so, `--sb-key` accepts a pkcs11 url, for example:
+To do so, `--sb-key` and `--tpm-pcr-private-key` accept a pkcs11 url, for example:
 
 ```bash
 docker run -ti --rm -v /run/pcscd:/run/pcscd -v $PWD/build:/result -v $PWD/keys/:/keys quay.io/kairos/auroraboot:{{< AuroraBootVersion  >}} build-uki -t iso -d /result/ --public-keys /keys --tpm-pcr-private-key $PATH_TO_TPM_KEY --sb-key "pkcs11:slot-id=1;id=%01" --sb-cert $PATH_TO_SB_CERT $CONTAINER_IMAGE


### PR DESCRIPTION
Updated the instructions to include '--tpm-pcr-private-key' for using a PKCS11 URL.

support for this was added on https://github.com/kairos-io/kairos/issues/4176 and aurora 0.25.0
