### PR TITLE
Fix mobile docs navbar overflow (kairos-io/kairos#4213)

### DIFF
--- a/src/components/ConditionalVersionDropdownNavbarItem.tsx
+++ b/src/components/ConditionalVersionDropdownNavbarItem.tsx
@@ -21,6 +21,7 @@ type ConditionalVersionDropdownNavbarItemProps = {
 export default function ConditionalVersionDropdownNavbarItem({
   routeBasePath,
   label,
+  mobile,
   ...dropdownProps
 }: ConditionalVersionDropdownNavbarItemProps): React.JSX.Element | null {
   const location = useLocation();
@@ -39,13 +40,14 @@ export default function ConditionalVersionDropdownNavbarItem({
   const dropdown = (
     <DocsVersionDropdownNavbarItem
       {...dropdownProps}
+      mobile={mobile}
       items={dropdownProps.items ?? []}
       dropdownItemsBefore={dropdownProps.dropdownItemsBefore ?? []}
       dropdownItemsAfter={dropdownProps.dropdownItemsAfter ?? []}
     />
   );
 
-  if (!label) {
+  if (!label || mobile) {
     return dropdown;
   }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -339,6 +339,35 @@ div[class*='announcementBar_'] button {
     width: 100%;
     margin: 8px 0;
   }
+
+  .navbar__toggle,
+  .navbar__brand {
+    flex: 0 0 auto;
+  }
+
+  /* Version dropdowns, flavor selector, stars, and search live in the burger menu */
+  .navbar__items--right {
+    display: none !important;
+  }
+
+  .navbar__items:not(.navbar__items--right) > .navbar__item.navbar__link {
+    display: inline-block !important;
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
+  .navbar-sidebar__search-item [class*='navbarSearchContainer'] {
+    display: block !important;
+    position: static;
+    width: 100%;
+    padding: 0.35rem 0.75rem 0.75rem;
+  }
+
+  .navbar-sidebar__search-item .navbar__search-input,
+  .navbar-sidebar__search-item .navbar-search-input {
+    width: 100%;
+    margin: 0;
+  }
 }
 
 /* Sidebar styling - Match navbar color scheme */

--- a/src/theme/Navbar/Content/index.tsx
+++ b/src/theme/Navbar/Content/index.tsx
@@ -1,0 +1,105 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {
+  useThemeConfig,
+  ErrorCauseBoundary,
+  ThemeClassNames,
+} from '@docusaurus/theme-common';
+import {
+  splitNavbarItems,
+  useNavbarMobileSidebar,
+} from '@docusaurus/theme-common/internal';
+import NavbarItem, {type Props as NavbarItemConfig} from '@theme/NavbarItem';
+import NavbarColorModeToggle from '@theme/Navbar/ColorModeToggle';
+import SearchBar from '@theme/SearchBar';
+import NavbarMobileSidebarToggle from '@theme/Navbar/MobileSidebar/Toggle';
+import NavbarLogo from '@theme/Navbar/Logo';
+import NavbarSearch from '@theme/Navbar/Search';
+
+import styles from './styles.module.css';
+
+function useNavbarItems() {
+  return useThemeConfig().navbar.items as NavbarItemConfig[];
+}
+
+function NavbarItems({items}: {items: NavbarItemConfig[]}): ReactNode {
+  return (
+    <>
+      {items.map((item, i) => (
+        <ErrorCauseBoundary
+          key={i}
+          onError={(error) =>
+            new Error(
+              `A theme navbar item failed to render.
+Please double-check the following navbar item (themeConfig.navbar.items) of your Docusaurus config:
+${JSON.stringify(item, null, 2)}`,
+              {cause: error},
+            )
+          }>
+          <NavbarItem {...item} />
+        </ErrorCauseBoundary>
+      ))}
+    </>
+  );
+}
+
+function NavbarContentLayout({
+  left,
+  right,
+}: {
+  left: ReactNode;
+  right: ReactNode;
+}) {
+  return (
+    <div className="navbar__inner">
+      <div
+        className={clsx(
+          ThemeClassNames.layout.navbar.containerLeft,
+          'navbar__items',
+        )}>
+        {left}
+      </div>
+      <div
+        className={clsx(
+          ThemeClassNames.layout.navbar.containerRight,
+          'navbar__items navbar__items--right',
+        )}>
+        {right}
+      </div>
+    </div>
+  );
+}
+
+export default function NavbarContent(): ReactNode {
+  const mobileSidebar = useNavbarMobileSidebar();
+
+  const items = useNavbarItems();
+  const [leftItems, rightItems] = splitNavbarItems(items);
+
+  const searchBarItem = items.find((item) => item.type === 'search');
+
+  return (
+    <NavbarContentLayout
+      left={
+        <>
+          {!mobileSidebar.disabled && <NavbarMobileSidebarToggle />}
+          <NavbarLogo />
+          <div className={styles.mobileNavScroll}>
+            <NavbarItems items={leftItems} />
+          </div>
+        </>
+      }
+      right={
+        <>
+          <NavbarItems items={rightItems} />
+          <NavbarColorModeToggle className={styles.colorModeToggle} />
+          {!searchBarItem && (
+            <NavbarSearch>
+              <SearchBar />
+            </NavbarSearch>
+          )}
+        </>
+      }
+    />
+  );
+}

--- a/src/theme/Navbar/Content/styles.module.css
+++ b/src/theme/Navbar/Content/styles.module.css
@@ -1,0 +1,26 @@
+@media (max-width: 996px) {
+  .colorModeToggle {
+    display: none;
+  }
+
+  .mobileNavScroll {
+    display: flex;
+    flex: 1;
+    min-width: 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    flex-wrap: nowrap;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-x: contain;
+    scrollbar-width: none;
+    align-items: center;
+  }
+
+  .mobileNavScroll::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+:global(.navbar__items--right) > :last-child {
+  padding-right: 0;
+}

--- a/src/theme/Navbar/MobileSidebar/SecondaryMenu/index.tsx
+++ b/src/theme/Navbar/MobileSidebar/SecondaryMenu/index.tsx
@@ -1,0 +1,43 @@
+import React, {type ComponentProps, type ReactNode} from 'react';
+import {useLocation} from '@docusaurus/router';
+import {useThemeConfig} from '@docusaurus/theme-common';
+import {useNavbarSecondaryMenu} from '@docusaurus/theme-common/internal';
+import Translate from '@docusaurus/Translate';
+import SearchBar from '@theme/SearchBar';
+import NavbarSearch from '@theme/Navbar/Search';
+import {isDocsMobileSearchRoute} from '@site/src/utils/mobileNavbarSearch';
+
+function SecondaryMenuBackButton(props: ComponentProps<'button'>) {
+  return (
+    <button {...props} type="button" className="clean-btn navbar-sidebar__back">
+      <Translate
+        id="theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel"
+        description="The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)">
+        ← Back to main menu
+      </Translate>
+    </button>
+  );
+}
+
+export default function NavbarMobileSidebarSecondaryMenu(): ReactNode {
+  const {pathname} = useLocation();
+  const isPrimaryMenuEmpty = useThemeConfig().navbar.items.length === 0;
+  const secondaryMenu = useNavbarSecondaryMenu();
+  const showSearch = isDocsMobileSearchRoute(pathname);
+
+  return (
+    <>
+      {!isPrimaryMenuEmpty && (
+        <SecondaryMenuBackButton onClick={() => secondaryMenu.hide()} />
+      )}
+      {showSearch && (
+        <div className="navbar-sidebar__search-item">
+          <NavbarSearch>
+            <SearchBar />
+          </NavbarSearch>
+        </div>
+      )}
+      {secondaryMenu.content}
+    </>
+  );
+}

--- a/src/theme/NavbarItem/SearchNavbarItem.tsx
+++ b/src/theme/NavbarItem/SearchNavbarItem.tsx
@@ -1,7 +1,9 @@
 import React, {type ReactNode} from 'react';
 import clsx from 'clsx';
+import {useLocation} from '@docusaurus/router';
 import SearchBar from '@theme/SearchBar';
 import NavbarSearch from '@theme/Navbar/Search';
+import {isDocsMobileSearchRoute} from '@site/src/utils/mobileNavbarSearch';
 import type {Props} from '@theme/NavbarItem/SearchNavbarItem';
 
 export default function SearchNavbarItem({
@@ -9,6 +11,11 @@ export default function SearchNavbarItem({
   className,
 }: Props): ReactNode {
   if (mobile) {
+    const {pathname} = useLocation();
+    if (isDocsMobileSearchRoute(pathname)) {
+      return null;
+    }
+
     return (
       <li className={clsx('menu__list-item', 'navbar-sidebar__search-item')}>
         <NavbarSearch className={className}>

--- a/src/theme/NavbarItem/SearchNavbarItem.tsx
+++ b/src/theme/NavbarItem/SearchNavbarItem.tsx
@@ -1,0 +1,26 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import SearchBar from '@theme/SearchBar';
+import NavbarSearch from '@theme/Navbar/Search';
+import type {Props} from '@theme/NavbarItem/SearchNavbarItem';
+
+export default function SearchNavbarItem({
+  mobile,
+  className,
+}: Props): ReactNode {
+  if (mobile) {
+    return (
+      <li className={clsx('menu__list-item', 'navbar-sidebar__search-item')}>
+        <NavbarSearch className={className}>
+          <SearchBar />
+        </NavbarSearch>
+      </li>
+    );
+  }
+
+  return (
+    <NavbarSearch className={className}>
+      <SearchBar />
+    </NavbarSearch>
+  );
+}

--- a/src/utils/mobileNavbarSearch.ts
+++ b/src/utils/mobileNavbarSearch.ts
@@ -1,0 +1,12 @@
+const DOC_MOBILE_SEARCH_PREFIXES = [
+  '/docs',
+  '/operator-docs',
+  '/quickstart',
+  '/hadron-docs',
+] as const;
+
+export function isDocsMobileSearchRoute(pathname: string): boolean {
+  return DOC_MOBILE_SEARCH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}


### PR DESCRIPTION
## Summary
- Moves search out of the cramped top navbar and into the burger menu on viewports ≤996px
- Hides right-side utility items (version dropdowns, flavor selector, GitHub stars) from the top bar on mobile; they remain available in the sidebar menu
- Makes primary nav links horizontally scrollable next to the fixed hamburger + logo

Fixes https://github.com/kairos-io/kairos/issues/4213

## Test plan
- [ ] Open a docs page (e.g. `/docs/`) on a mobile viewport (≤996px)
- [ ] Confirm top bar shows hamburger, logo, and scrollable nav links without overlap
- [ ] Confirm search is not in the top bar
- [ ] Open burger menu and confirm search, version selector, flavor selector, and GitHub link are available
- [ ] Verify desktop navbar layout is unchanged


Made with [Cursor](https://cursor.com)