### PR TITLE
docs(operator): GitOps install, supply-chain security, and NodeOpUpgrade name-bump pattern

### DIFF
--- a/operator-docs/installation.md
+++ b/operator-docs/installation.md
@@ -48,3 +48,77 @@ To remove the operator installed via bundle, you need to delete the `kairos-oper
 
 - **k0s**: `/var/lib/k0s/manifests/kairos-operator/`
 - **k3s**: `/var/lib/rancher/k3s/server/manifests/`
+
+## Installing via GitOps (ArgoCD)
+
+The operator does not currently publish a Helm chart, so GitOps deployments point directly at the upstream `config/default` kustomize source and let ArgoCD render it. A minimal `Application` looks like:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kairos-operator
+  namespace: argocd
+  annotations:
+    # Sync-wave places the operator ahead of any NodeOpUpgrade / NodeOp / OSArtifact
+    # CRs applied from the same app-of-apps root.
+    argocd.argoproj.io/sync-wave: "-10"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/kairos-io/kairos-operator.git
+    targetRevision: v0.0.7                # pin to a released tag; bump via a PR
+    path: config/default
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kairos-operator
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true               # required — the CRDs exceed the 262 kB annotation size limit of client-side apply
+```
+
+Notes:
+
+- `path: config/default` matches the `kubectl apply -k` install above. Both call the same kustomization; ArgoCD just materializes the result.
+- `ServerSideApply=true` is required. The operator's CRDs (in particular `OSArtifact`) exceed the 262 kB `last-applied-configuration` annotation limit and fail with `metadata.annotations: Too long` under client-side apply.
+- `syncOptions.CreateNamespace=true` lets ArgoCD create `spec.destination.namespace` on first sync. The upstream kustomization creates its own `operator-system` namespace; the value above just gives unscoped resources a home.
+
+### CRD race condition when applying downstream CRs
+
+If you commit a `NodeOpUpgrade` / `NodeOp` / `OSArtifact` CR in the same app-of-apps root as the operator install, ArgoCD's pre-sync dry-run validates each resource against the cluster's discovery cache. On the first bootstrap the operator's CRDs are not yet registered, so the dry-run fails with:
+
+```
+the server could not find the requested resource (kind=NodeOpUpgrade)
+one or more synchronization tasks are not valid
+```
+
+Even with `sync-wave` ordering the operator's `Application` reports "Synced" the moment its manifest lands in Kubernetes — not when the CRDs are actually reconciled. The downstream CR then races ahead and 5× retry-fails.
+
+Two mitigations, use both:
+
+**1. Annotate downstream CRs to defer dry-run** until the CRD appears:
+
+```yaml
+apiVersion: operator.kairos.io/v1alpha1
+kind: NodeOpUpgrade
+metadata:
+  name: kairos-upgrade
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  # …
+```
+
+**2. Sequence with sync-waves** — put the operator's `Application` at a lower wave than the CRs so ArgoCD attempts the operator install first. A typical layout:
+
+| Wave | Resource |
+|---|---|
+| `-20` | `Application/kyverno` (Helm chart + `ClusterPolicy` resources) — see [Supply-chain security](supply-chain#bootstrap-ordering-with-argocd) |
+| `-10` | `Application/kairos-operator` |
+| `0` (default) | `NodeOpUpgrade`, `NodeOp`, `OSArtifact` CRs |
+
+`SkipDryRunOnMissingResource=true` is the actual mechanism that unblocks the sync; sync-wave ordering just reduces how many times ArgoCD retries before the CRD shows up.

--- a/operator-docs/installation.md
+++ b/operator-docs/installation.md
@@ -117,7 +117,7 @@ spec:
 
 | Wave | Resource |
 |---|---|
-| `-20` | `Application/kyverno` (Helm chart + `ClusterPolicy` resources) — see [Supply-chain security](supply-chain#bootstrap-ordering-with-argocd) |
+| `-20` | `Application/kyverno` (Helm chart + `ClusterPolicy` resources) — see [Supply-chain security](../supply-chain#bootstrap-ordering-with-argocd) |
 | `-10` | `Application/kairos-operator` |
 | `0` (default) | `NodeOpUpgrade`, `NodeOp`, `OSArtifact` CRs |
 

--- a/operator-docs/nodeop-upgrade.md
+++ b/operator-docs/nodeop-upgrade.md
@@ -86,7 +86,7 @@ Three things to note:
 - The second custom manager handles `metadata.name`. `currentValueTemplate` converts the dash-format slug (`v0-3-0` → `v0.3.0`) so Renovate can compare it against the docker datasource. `autoReplaceStringTemplate` writes the new version back in dash-format. Both managers share the same `depNameTemplate`, so Renovate updates `spec.image` and `metadata.name` atomically in one PR.
 - **Do not use `extractVersionTemplate`** to parse the dash-format in `metadata.name` — it is not a valid field for Renovate custom managers and is silently ignored. The result is that `spec.image` gets bumped but `metadata.name` stays at the old version, so the operator sees no new CR and does nothing.
 
-The pattern is not superior to `generateName` — it's a different tradeoff. Pick `generateName` when you drive upgrades from a CLI or CI job. Pick static-name bump when the desired state lives in git and every change goes through a merged PR.
+`generateName` and static-name bump are equivalent in semantics — both produce a new one-shot CR. The difference is operational: `generateName` suits imperative workflows (CLI, CI job) where the run doesn't need to live in git. Static-name bump suits GitOps where every change is a reviewed commit.
 
 ## Basic Example
 

--- a/operator-docs/nodeop-upgrade.md
+++ b/operator-docs/nodeop-upgrade.md
@@ -82,7 +82,7 @@ For [Renovate](https://docs.renovatebot.com/), a custom regex manager targeting 
 
 Three things to note:
 
-- `allowedVersions` clamps updates to a single k3s minor line. This prevents a Renovate PR from silently proposing a k3s minor bump alongside a Kairos patch bump. To cross a k3s minor, edit the regex in a separate PR — forces an explicit decision.
+- `allowedVersions` pins updates to the current k3s minor line (`1.35.x`). This prevents Renovate from silently bundling a k3s minor upgrade with a Kairos patch bump. To adopt a new k3s minor, update the regex explicitly.
 - The second custom manager handles `metadata.name`. `currentValueTemplate` converts the dash-format slug (`v0-3-0` → `v0.3.0`) so Renovate can compare it against the docker datasource. `autoReplaceStringTemplate` writes the new version back in dash-format. Both managers share the same `depNameTemplate`, so Renovate updates `spec.image` and `metadata.name` atomically in one PR.
 - **Do not use `extractVersionTemplate`** to parse the dash-format in `metadata.name` — it is not a valid field for Renovate custom managers and is silently ignored. The result is that `spec.image` gets bumped but `metadata.name` stays at the old version, so the operator sees no new CR and does nothing.
 

--- a/operator-docs/nodeop-upgrade.md
+++ b/operator-docs/nodeop-upgrade.md
@@ -18,6 +18,76 @@ A `NodeOpUpgrade` represents a **single upgrade run** on the target nodes. The o
 
 To run the same upgrade configuration repeatedly, use **metadata.generateName** instead of **metadata.name** and **kubectl create** (not **apply**) so each run creates a new NodeOpUpgrade. See [NodeOp: One-off operations and reusing manifests](../nodeop/#one-off-operations-and-reusing-manifests) for the same pattern and rationale.
 
+### GitOps alternative: static-name bump with a versioned suffix
+
+`generateName` + `kubectl create` is an imperative workflow — the CR name is unknown ahead of time and the run doesn't live in git. In a GitOps setup (ArgoCD / Flux / etc.) both properties are inverted: every resource has a known static name that git owns, and drift-detection expects the same name to describe the same object across reconciliations.
+
+The GitOps equivalent of "new run = new object" is to make the **version part of the name**, and bump the name and the image reference in the same commit. Each merged commit produces a new named resource, which the operator treats as a new one-shot run. Same semantic guarantee as `generateName`, but declarative and reviewable.
+
+```yaml
+apiVersion: operator.kairos.io/v1alpha1
+kind: NodeOpUpgrade
+# The version fragment in the name is REQUIRED. Same name across two commits
+# would look like a spec update to the operator (behavior undefined per the
+# warning above). Bumping the name makes the new commit a new object.
+metadata:
+  name: kairos-upgrade-v3-4-2                     # <-- bumped alongside spec.image
+  namespace: default
+spec:
+  image: quay.io/kairos/opensuse:leap-15.6-standard-amd64-generic-v3.4.2-k3sv1.30.11-k3s1
+  concurrency: 1
+  stopOnFailure: true
+```
+
+Bumping the name by hand at every release defeats the point of GitOps. A dependency-update bot (Renovate, dependabot, etc.) can watch the image tag and open a PR that rewrites **both** the `image:` line and the version fragment in `metadata.name:`.
+
+For [Renovate](https://docs.renovatebot.com/), a custom regex manager targeting a composite tag (Kairos + k8s version) looks like:
+
+```json
+{
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^upgrades/.*\\.ya?ml$"],
+      "matchStrings": [
+        "image:\\s+quay\\.io/kairos/hadron:(?<currentValue>v\\d+\\.\\d+\\.\\d+-standard-(?:amd64|arm64)-generic-v\\d+\\.\\d+\\.\\d+-k3s-v\\d+\\.\\d+\\.\\d+-k3s1)"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "quay.io/kairos/hadron",
+      "versioningTemplate": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-standard-(?:amd64|arm64)-generic-v\\d+\\.\\d+\\.\\d+-k3s-v\\d+\\.\\d+\\.\\d+-k3s1$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^upgrades/.*\\.ya?ml$"],
+      "matchStrings": [
+        "name:\\s+hadron-(?<cluster>[a-z]+)-v(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)"
+      ],
+      "currentValueTemplate": "v{{{major}}}.{{{minor}}}.{{{patch}}}",
+      "autoReplaceStringTemplate": "name: hadron-{{{cluster}}}-v{{{newMajor}}}-{{{newMinor}}}-{{{newPatch}}}",
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "quay.io/kairos/hadron",
+      "versioningTemplate": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-standard-(?:amd64|arm64)-generic-v\\d+\\.\\d+\\.\\d+-k3s-v\\d+\\.\\d+\\.\\d+-k3s1$"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["quay.io/kairos/hadron"],
+      "allowedVersions": "/.*-k3s-v1\\.35\\.\\d+-k3s1$/",
+      "minimumReleaseAge": "24 hours",
+      "automerge": false
+    }
+  ]
+}
+```
+
+Three things to note:
+
+- `allowedVersions` clamps updates to a single k3s minor line. This prevents a Renovate PR from silently proposing a k3s minor bump alongside a Kairos patch bump. To cross a k3s minor, edit the regex in a separate PR — forces an explicit decision.
+- The second custom manager handles `metadata.name`. `currentValueTemplate` converts the dash-format slug (`v0-3-0` → `v0.3.0`) so Renovate can compare it against the docker datasource. `autoReplaceStringTemplate` writes the new version back in dash-format. Both managers share the same `depNameTemplate`, so Renovate updates `spec.image` and `metadata.name` atomically in one PR.
+- **Do not use `extractVersionTemplate`** to parse the dash-format in `metadata.name` — it is not a valid field for Renovate custom managers and is silently ignored. The result is that `spec.image` gets bumped but `metadata.name` stays at the old version, so the operator sees no new CR and does nothing.
+
+The pattern is not superior to `generateName` — it's a different tradeoff. Pick `generateName` when you drive upgrades from a CLI or CI job. Pick static-name bump when the desired state lives in git and every change goes through a merged PR.
+
 ## Basic Example
 
 The following is an example of a "canary upgrade", which upgrades Kairos nodes one-by-one (master nodes first). It will stop upgrading if one of the nodes doesn't complete the upgrade and reboot successfully.

--- a/operator-docs/supply-chain.md
+++ b/operator-docs/supply-chain.md
@@ -1,0 +1,154 @@
+---
+title: "Supply-chain security"
+linkTitle: "Supply-chain security"
+weight: 6
+date: 2026-07-03
+description: Verify Kairos upgrade images and constrain NodeOpUpgrade image sources at admission time
+---
+
+The Kairos operator pulls container images that run **as root on the host** and write directly to the node's A/B partition during an upgrade. A tampered or attacker-controlled image lands where a rootkit would want to land. Two admission-time gates make this materially harder:
+
+1. **Image origin restriction** — enforce that `NodeOpUpgrade.spec.image` may only reference an allow-listed registry / repository. Blocks a compromised or misconfigured CR from redirecting an upgrade to an arbitrary image.
+2. **Signature verification** — verify that every pulled upgrade image is cosign-signed by the upstream Kairos release CI before the pod is admitted. Blocks a valid registry path serving a tampered image.
+
+Both are Kyverno `ClusterPolicy` resources. They are additive: the first stops an attacker who can create a `NodeOpUpgrade` but not push to the trusted registry; the second stops an attacker who can push to a look-alike path in the trusted registry but not sign as the upstream CI.
+
+Neither policy is shipped by the operator itself. This page documents the recipe.
+
+## Prerequisites
+
+- A Kubernetes cluster with the [Kairos operator](installation) installed.
+- [Kyverno](https://kyverno.io/) installed, with the `verifyImages` webhook enabled (default in recent releases).
+- Access to the [Sigstore public infrastructure](https://docs.sigstore.dev/) (`fulcio.sigstore.dev`, `rekor.sigstore.dev`) from within the cluster, OR a local Sigstore stack if you run air-gapped.
+
+## Policy 1 — restrict NodeOpUpgrade image source
+
+The following `ClusterPolicy` refuses any `NodeOpUpgrade` whose `spec.image` does not match the trusted upstream Hadron path.
+
+```yaml
+apiVersion: kyverno.io/v2beta1
+kind: ClusterPolicy
+metadata:
+  name: restrict-nodeopupgrade-image
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    policies.kyverno.io/title: Restrict NodeOpUpgrade Image Source
+    policies.kyverno.io/category: Supply Chain Security
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: NodeOpUpgrade
+spec:
+  validationFailureAction: Enforce
+  background: false
+  rules:
+    - name: restrict-image-to-hadron
+      match:
+        any:
+          - resources:
+              kinds:
+                - NodeOpUpgrade
+              operations:
+                - CREATE
+                - UPDATE
+      validate:
+        message: >-
+          NodeOpUpgrade spec.image must reference quay.io/kairos/hadron:*.
+          Got: {{ request.object.spec.image }}
+        pattern:
+          spec:
+            image: "quay.io/kairos/hadron:*"
+```
+
+- `SkipDryRunOnMissingResource=true` is only needed if you deploy this policy alongside the operator via ArgoCD before its CRDs are registered — see the [CRD race condition note](installation#crd-race-condition-when-applying-downstream-crs) in the installation page.
+- Adapt the allow-listed path to the image family you actually rely on. If you build your own upgrade image via [BYOI](/docs/reference/byoi/) or [Kairos Factory](/docs/reference/kairos-factory/), point the pattern at your own registry path instead.
+- Because Kyverno cannot re-evaluate `spec.image` under a `generateName` create (the CR does not yet have a fully-qualified name), match on `CREATE` and `UPDATE` as above.
+
+## Policy 2 — verify cosign signature at pod admission
+
+Upstream Kairos images ([Hadron](https://github.com/kairos-io/hadron)) are cosign-signed at release time by the [Hadron CI](https://github.com/kairos-io/hadron/actions) using a GitHub Actions OIDC identity. The signature is issued by [Sigstore Fulcio](https://docs.sigstore.dev/certificate_authority/overview/) as a short-lived certificate and logged in [Rekor](https://docs.sigstore.dev/logging/overview/). There is no long-lived key material; the trust anchor is the OIDC issuer + subject pair.
+
+The Kyverno policy below reproduces that trust chain at pod admission time and blocks any `quay.io/kairos/hadron:*` pod whose image is unsigned or whose signature does not chain to the Hadron CI identity.
+
+```yaml
+apiVersion: kyverno.io/v2beta1
+kind: ClusterPolicy
+metadata:
+  name: verify-hadron-cosign-signature
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    policies.kyverno.io/title: Verify Hadron Cosign Signature
+    policies.kyverno.io/category: Supply Chain Security
+    policies.kyverno.io/severity: high
+spec:
+  validationFailureAction: Enforce
+  background: false
+  webhookTimeoutSeconds: 30
+  failurePolicy: Fail
+  rules:
+    - name: verify-quay-hadron-cosign-keyless
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      verifyImages:
+        - imageReferences:
+            - "quay.io/kairos/hadron:*"
+          required: true
+          mutateDigest: true
+          verifyDigest: true
+          attestors:
+            - count: 1
+              entries:
+                - keyless:
+                    issuer: "https://token.actions.githubusercontent.com"
+                    subject: "https://github.com/kairos-io/hadron/.github/workflows/build-multiarch-images.yml@refs/tags/*"
+                    rekor:
+                      url: https://rekor.sigstore.dev
+```
+
+A few subtleties:
+
+- `mutateDigest: true` rewrites the pod's `image: quay.io/kairos/hadron:vX` reference to its resolved digest at admission. This prevents a tag-swap attack after the signature check runs.
+- `webhookTimeoutSeconds: 30` and `failurePolicy: Fail` mean a Sigstore outage will block hadron pod admission. On air-gapped clusters point `rekor.url` at your local Rekor instance and drop `attestors.entries.keyless.rekor` to the private CA equivalent.
+- If the upstream Hadron CI moves its workflow file or renames the repo, the `subject` regex must move with it. Track upstream at [github.com/kairos-io/hadron](https://github.com/kairos-io/hadron/tree/main/.github/workflows).
+
+You can also verify manually from a laptop before signing off on an upgrade:
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp='^https://github.com/kairos-io/hadron/' \
+  quay.io/kairos/hadron:<tag>
+```
+
+## Bootstrap ordering with ArgoCD
+
+If you install Kyverno and the operator from the same GitOps root, wave-order Kyverno first so that policies are evaluating admission by the time the operator (and the first `NodeOpUpgrade`) attempts to run:
+
+| Wave | Resource |
+|---|---|
+| `-20` | `Application/kyverno` (chart + these `ClusterPolicy` resources) |
+| `-10` | `Application/kairos-operator` |
+| `0` (default) | `NodeOpUpgrade` CRs |
+
+Without this ordering there is a window during first bootstrap in which the operator can be admitted but the policies are not yet enforcing, so an unsigned hadron image would slip through. Re-verify wave ordering after any chart upgrade.
+
+## Threat model — what this gates and what it doesn't
+
+**Gated:**
+
+- Attacker with cluster-admin who tries to point `NodeOpUpgrade.spec.image` at their own registry — blocked by Policy 1.
+- Attacker who takes over `quay.io/kairos/hadron` at the registry layer and pushes a tampered image with the correct tag — blocked by Policy 2 (no valid Sigstore signature).
+- Tag-swap after signature check — blocked by `mutateDigest: true`.
+
+**Not gated:**
+
+- Attacker who compromises the Hadron CI itself (they can produce signatures with the expected OIDC subject). Defense: watch for anomalous release cadence, verify SBOMs, and pin `subject` to specific tag patterns rather than `refs/tags/*` when your risk tolerance requires it.
+- Attacker with node-level root (the upgrade image runs as root by design; if the attacker is already there, the operator is not the weakest link).
+- Attacker who compromises the Sigstore infrastructure. Defense: run a private Sigstore stack for air-gapped or high-assurance deployments.
+
+## See also
+
+- [NodeOpUpgrade — GitOps static-name-bump pattern](nodeop-upgrade#gitops-alternative-static-name-bump-with-a-versioned-suffix) — pairs well with Policy 2, because Renovate PRs re-verify the tag signature before merge.
+- [Using Private Registries](private-registries) — for authenticated registries in front of the trusted image path.
+- [Kyverno verifyImages documentation](https://kyverno.io/docs/writing-policies/verify-images/)

--- a/operator-docs/supply-chain.md
+++ b/operator-docs/supply-chain.md
@@ -17,7 +17,7 @@ Neither policy is shipped by the operator itself. This page documents the recipe
 
 ## Prerequisites
 
-- A Kubernetes cluster with the [Kairos operator](installation) installed.
+- A Kubernetes cluster with the [Kairos operator](../installation) installed.
 - [Kyverno](https://kyverno.io/) installed, with the `verifyImages` webhook enabled (default in recent releases).
 - Access to the [Sigstore public infrastructure](https://docs.sigstore.dev/) (`fulcio.sigstore.dev`, `rekor.sigstore.dev`) from within the cluster, OR a local Sigstore stack if you run air-gapped.
 
@@ -58,7 +58,7 @@ spec:
             image: "quay.io/kairos/hadron:*"
 ```
 
-- `SkipDryRunOnMissingResource=true` is only needed if you deploy this policy alongside the operator via ArgoCD before its CRDs are registered — see the [CRD race condition note](installation#crd-race-condition-when-applying-downstream-crs) in the installation page.
+- `SkipDryRunOnMissingResource=true` is only needed if you deploy this policy alongside the operator via ArgoCD before its CRDs are registered — see the [CRD race condition note](../installation#crd-race-condition-when-applying-downstream-crs) in the installation page.
 - Adapt the allow-listed path to the image family you actually rely on. If you build your own upgrade image via [BYOI](/docs/reference/byoi/) or [Kairos Factory](/docs/reference/kairos-factory/), point the pattern at your own registry path instead.
 - Because Kyverno cannot re-evaluate `spec.image` under a `generateName` create (the CR does not yet have a fully-qualified name), match on `CREATE` and `UPDATE` as above.
 
@@ -149,6 +149,6 @@ Without this ordering there is a window during first bootstrap in which the oper
 
 ## See also
 
-- [NodeOpUpgrade — GitOps static-name-bump pattern](nodeop-upgrade#gitops-alternative-static-name-bump-with-a-versioned-suffix) — pairs well with Policy 2, because Renovate PRs re-verify the tag signature before merge.
-- [Using Private Registries](private-registries) — for authenticated registries in front of the trusted image path.
+- [NodeOpUpgrade — GitOps static-name-bump pattern](../nodeop-upgrade#gitops-alternative-static-name-bump-with-a-versioned-suffix) — pairs well with Policy 2, because Renovate PRs re-verify the tag signature before merge.
+- [Using Private Registries](../private-registries) — for authenticated registries in front of the trusted image path.
 - [Kyverno verifyImages documentation](https://kyverno.io/docs/writing-policies/verify-images/)


### PR DESCRIPTION
## What this adds

Three interconnected additions covering the full GitOps + supply-chain pipeline for the Kairos operator.

---

### 1. GitOps install via ArgoCD (`installation.md`)

The operator has no Helm chart. This documents deploying it via ArgoCD pointing at the upstream kustomize source, with two non-obvious pitfalls:

- `ServerSideApply=true` is required — the operator CRDs exceed the 262 kB client-side apply annotation limit
- CRD race condition on first bootstrap: downstream `NodeOpUpgrade` / `NodeOp` / `OSArtifact` CRs fail dry-run because CRDs aren't registered yet, even with sync-wave ordering

Two mitigations documented (use both): `SkipDryRunOnMissingResource=true` on downstream CRs + sync-wave ordering:

| Wave | Resource |
|---|---|
| `-20` | `Application/kyverno` (chart + ClusterPolicy resources) |
| `-10` | `Application/kairos-operator` |
| `0` | `NodeOpUpgrade`, `NodeOp`, `OSArtifact` CRs |

---

### 2. Supply-chain security (`supply-chain.md`, new page)

The operator pulls images that run as root on the host and write to the node's A/B partition. Two Kyverno admission gates documented:

**Policy 1 — restrict image source**: `ClusterPolicy` enforcing `NodeOpUpgrade.spec.image` must match `quay.io/kairos/hadron:*`. Blocks misdirected upgrades.

**Policy 2 — verify cosign signature**: Kyverno `verifyImages` with keyless attestor pinned to the Hadron CI identity:
- issuer: `https://token.actions.githubusercontent.com`
- subject: `https://github.com/kairos-io/hadron/.github/workflows/build-multiarch-images.yml@refs/tags/*`
- `mutateDigest: true` prevents tag-swap after check
- Air-gapped note: point `rekor.url` at local Rekor instance

Includes threat model (what is and isn't gated) and bootstrap wave ordering cross-linked with `installation.md`.

---

### 3. NodeOpUpgrade GitOps name-bump pattern + Renovate fix (`nodeop-upgrade.md`)

Documents the GitOps alternative to `generateName`: embed the version in `metadata.name` and bump it alongside `spec.image` in the same commit so the operator sees a new one-shot CR on every merge.

Complete Renovate custom-manager config with **two** `matchStrings` entries — one for `spec.image`, one for `metadata.name`:

- `currentValueTemplate` converts dash-format `v0-3-0` → `v0.3.0` for datasource comparison
- `autoReplaceStringTemplate` writes new version back in dash-format
- Both managers share the same `depNameTemplate` → atomic update in one PR

**Bug documented**: `extractVersionTemplate` is not a valid Renovate custom-manager field and is silently ignored. Using it causes `spec.image` to be bumped but `metadata.name` to stay at the old version — the operator sees no new CR and does nothing.

## Test plan

- [ ] Verify Docusaurus build passes (cross-links between `installation.md` → `supply-chain.md` and `nodeop-upgrade.md`)
- [ ] Verify `supply-chain.md` appears in the operator-docs sidebar
- [ ] Verify cosign policy subject matches current Hadron CI workflow filename (`build-multiarch-images.yml` — confirmed present in repo)