### PR TITLE
docs: explain how to extract the raw image from the -img artifact

### DIFF
--- a/docs/installation/edge-devices/raspberry.md
+++ b/docs/installation/edge-devices/raspberry.md
@@ -48,7 +48,7 @@ sudo dd if=build/{{< Image variant="standard" model="rpi4" arch="arm64" suffix="
 
 ### Download
 
-Extract the `img` file from a container image as described [in this page](/docs/reference/image_matrix)
+Extract the raw image from the published `-img` container image as described in [Extracting a raw image from a container image](/docs/reference/image_matrix#extracting-a-raw-image-from-a-container-image).
 
 ### Flash the image
 

--- a/docs/reference/image_matrix.md
+++ b/docs/reference/image_matrix.md
@@ -55,6 +55,31 @@ docker build --platform linux/arm64 --build-arg BASE_IMG=almalinux:9 --build-arg
 :::tip Note
 See [Kairos Factory](/docs/reference/kairos-factory/) for a production-ready path to automate this in CI.
 :::
+
+### Extracting a raw image from a container image
+
+Raw disk images (for example the Raspberry Pi `.raw`) are not attached to GitHub releases, because they exceed GitHub's 2 GiB per-file asset limit. Instead they are published as an OCI artifact whose tag ends in `-img`.
+
+That artifact is built from [`images/Dockerfile.img`](https://github.com/kairos-io/kairos/blob/master/images/Dockerfile.img), which simply carries the raw file:
+
+```dockerfile
+FROM scratch
+ARG ARTIFACT
+COPY $ARTIFACT /$ARTIFACT
+```
+
+Because it is a `scratch` image, you can pull the raw file out with plain Docker — no extra tooling:
+
+```bash
+export IMAGE=<registry>/<repository>:<tag>-img
+# scratch images have no default command, so pass a throwaway one (it is never executed)
+container=$(docker create "$IMAGE" noop)
+docker cp "$container:/artifacts/." .
+docker rm "$container"
+```
+
+The `.raw` image is now in the current directory, ready to flash.
+
 ## Versioning policy
 
 Kairos follows [Semantic Versioning](https://semver.org/) and our releases signal changes to Kairos components, rather than changes to the underlying OS and package versions. Flavors are pinned to specific upstream OS branches (e.g. `opensuse` to `leap 15.4`) and major version bumps will be reflected through new flavors in our build matrix or through specific releases to follow upstream with regard to minor version bumps (e.g. `leap 15.3` and `leap 15.4`).


### PR DESCRIPTION
## What

The Raspberry Pi installation page tells users to "extract the img file from a container image as described in [the image matrix page]", but that reference page no longer documents *how* to do it — the previous `luet`-based instructions were removed, leaving a dead end for anyone trying to obtain a raw/RPi image.

This adds an **"Extracting a raw image from a container image"** section to the image matrix reference, explaining the Docker-only method (the `-img` tag is a `scratch` image that carries the raw under `/artifacts`), and links the Raspberry Pi "Download" step directly to it.

## Why Docker (no luet)

The `-img` artifact is built from `images/Dockerfile.img` (`FROM scratch` + `COPY $ARTIFACT /$ARTIFACT`), so `docker create` + `docker cp` pulls the raw out with no extra tooling. Verified end to end against a `kairos-factory-action@v1.1.3` RPi4 build — it extracts the full ~5 GB `.raw`.

Fixes kairos-io/kairos#4232 — companion to kairos-io/kairos#4231 (automating the same instructions in the factory action's release notes).