### PR TITLE
fix: sync adopters page files in release automation

### DIFF
--- a/scripts/release-automation.sh
+++ b/scripts/release-automation.sh
@@ -190,12 +190,21 @@ ensure_release_branch() {
 
 sync_build_files_from_main() {
     if [ "$DRY_RUN" = true ]; then
-        log "INFO" "[DRY RUN] Would sync build files, config, and blog from main"
+        log "INFO" "[DRY RUN] Would sync build files, config, blog, and site-wide pages from main"
         return 0
     fi
 
-    log "INFO" "Syncing build configuration files, docusaurus config, and blog from main branch"
-    git checkout origin/main -- package.json package-lock.json docusaurus.config.ts blog/
+    log "INFO" "Syncing build configuration files, docusaurus config, blog, and site-wide pages from main branch"
+    git checkout origin/main -- \
+        package.json \
+        package-lock.json \
+        docusaurus.config.ts \
+        blog/ \
+        src/pages/adopters/ \
+        src/pages/index.tsx \
+        src/components/adopters/ \
+        src/components/designs/content.ts \
+        static/img/adopters/
     npm ci
     log "INFO" "Build files synced and dependencies installed"
 }


### PR DESCRIPTION
## Summary
- Extend `sync_build_files_from_main()` to pull adopters page assets from `main` alongside `docusaurus.config.ts`
- Fixes Release Monitor build failures caused by broken `/adopters/` links on release branches after #633

## Context
The Release Monitor workflow checks out a release branch, syncs build config from `main`, and runs `npm run build`. PR #633 added an Adopters footer link in `docusaurus.config.ts`, but the adopters page and related assets only exist on `main`. Release branches therefore failed Docusaurus broken-link validation on every page.

## Test plan
- [x] Reproduced failure locally on `release/v4.1.2` with config-only sync
- [x] Verified `npm run build` succeeds after syncing the adopters files listed in this change


Made with [Cursor](https://cursor.com)