### PR TITLE
docs: split NVIDIA docs into discrete x86 and Jetson Thor paths

### DIFF
--- a/docs/installation/edge-devices/nvidia-jetson-images.md
+++ b/docs/installation/edge-devices/nvidia-jetson-images.md
@@ -1,0 +1,153 @@
+---
+title: "Building Kairos images for NVIDIA Jetson"
+sidebar_label: "NVIDIA Jetson (build image)"
+sidebar_position: 1
+date: 2026-07-17
+description: Build a Kairos image for a Jetson AGX Orin, Orin NX or AGX Thor via kairos-init.
+slug: /installation/nvidia-jetson-images
+---
+
+`kairos-init` supports three NVIDIA Jetson boards through the `--model` flag. Passing the right
+model is enough — you no longer need a hand-written `Dockerfile.nvidia`. This page walks through
+the build; the per-board flashing steps stay on the existing device pages linked below.
+
+:::info Where did `Dockerfile.nvidia` go?
+Kairos used to ship [`images/Dockerfile.nvidia`](https://github.com/kairos-io/kairos/blob/v3.5.6/images/Dockerfile.nvidia)
+in the main repo. Everything it did — enabling the NVIDIA L4T apt repos, installing
+`nvidia-l4t-*` packages, wiring the Tegra kernel, disabling boot firmware updates in
+preinstall — is now applied automatically by `kairos-init` when you pass a Jetson `--model`.
+The `Dockerfile.nvidia` was removed once the logic moved into `kairos-init`; this page is its
+replacement.
+:::
+
+## Supported Jetson models
+
+| `--model`                | Board                                     | L4T family | Base image        |
+|--------------------------|-------------------------------------------|------------|-------------------|
+| `nvidia-jetson-agx-orin` | [Jetson AGX Orin](/docs/installation/nvidia_agx_orin/)   | r36.x      | `ubuntu:22.04`    |
+| `nvidia-jetson-orin-nx`  | [Jetson Orin NX](/docs/installation/nvidia_orin_nx/)     | r36.x      | `ubuntu:22.04`    |
+| `nvidia-jetson-thor`     | [Jetson AGX Thor](/docs/installation/nvidia_agx_thor/)   | r38.x      | `ubuntu:24.04` or Hadron |
+
+For the full list of `--model` values (including `generic`, `rpi3`, `rpi4`) see
+[The Kairos Factory](/docs/reference/kairos-factory/#supported-device-targets).
+
+## Prerequisites
+
+- Docker with `buildx`.
+- Build platform is `linux/arm64` — either a native ARM host, cross-build via QEMU
+  (`--platform linux/arm64`) or an ARM GitHub Actions runner.
+- `kairos-init` `v0.9.0` or newer for AGX Orin / Orin NX; `v0.9.0`+ is also the minimum for
+  Thor support. Check [Kairos releases](https://github.com/kairos-io/kairos-init/releases) for
+  the newest tag; this page uses `{{< KairosInitVersion >}}`.
+
+## Build the image
+
+The Dockerfile is the standard Kairos Factory shape — only `--model` changes per board.
+
+### AGX Orin (Ubuntu 22.04)
+
+```Dockerfile
+FROM quay.io/kairos/kairos-init:{{< KairosInitVersion >}} AS kairos-init
+
+FROM ubuntu:22.04
+ARG VERSION=1.0.0
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init --version "${VERSION}" --model nvidia-jetson-agx-orin
+```
+
+### Orin NX (Ubuntu 22.04)
+
+```Dockerfile
+FROM quay.io/kairos/kairos-init:{{< KairosInitVersion >}} AS kairos-init
+
+FROM ubuntu:22.04
+ARG VERSION=1.0.0
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init --version "${VERSION}" --model nvidia-jetson-orin-nx
+```
+
+### AGX Thor (Ubuntu 24.04 or Hadron)
+
+Thor has two supported base images. Ubuntu 24.04 is the drop-in equivalent to the flow above;
+Hadron is a musl-based from-scratch base that requires a pre-build step (see the Thor page for
+details). The `--model` flag is the same.
+
+```Dockerfile
+FROM quay.io/kairos/kairos-init:{{< KairosInitVersion >}} AS kairos-init
+
+FROM ubuntu:24.04
+ARG VERSION=1.0.0
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init --version "${VERSION}" --model nvidia-jetson-thor
+```
+
+For the Hadron variant, follow [Nvidia AGX Thor](/docs/installation/nvidia_agx_thor/) — it
+builds a Thor-specific Hadron base first, then runs the same `kairos-init` step with
+`--model nvidia-jetson-thor`.
+
+## Build for `linux/arm64`
+
+If your workstation is not ARM, cross-build via QEMU:
+
+```bash
+docker buildx build --platform linux/arm64 \
+  -t my-registry.example.com/kairos-agx-orin:v1.0.0 \
+  --push .
+```
+
+On a native ARM host you can drop `--platform` and use plain `docker build`.
+
+## What `--model` does under the hood
+
+For any of the Jetson models, `kairos-init`:
+
+- Adds the appropriate NVIDIA L4T apt repos
+  (`https://repo.download.nvidia.com/jetson/common r<L4T>` and the board-specific
+  `t234` / `t264` repo).
+- Installs the `nvidia-l4t-*` package set (kernel, bootloader, firmware, CUDA runtime,
+  multimedia, tools, etc.) matching the L4T family.
+- Wires up the Tegra kernel and initrd so `/boot/vmlinuz` and `/boot/initrd` point at the
+  Tegra artifacts, not the generic Ubuntu ones.
+- Applies the [`12_nvidia.yaml`](https://github.com/kairos-io/kairos-init/blob/main/pkg/bundled/cloudconfigs/12_nvidia.yaml)
+  cloud-config (disables `nv-l4t-boot-fw-update-in-preinstall`, sets up the Tegra rootfs prep,
+  etc.).
+- Enables the required systemd services for the board.
+
+None of this needs to be written by hand — the flag pulls in everything the old
+`Dockerfile.nvidia` used to do, and stays current with L4T releases as `kairos-init` is
+updated.
+
+## Add providers, FIPS, Trusted Boot, ...
+
+Everything the Kairos Factory supports composes with `--model`. To bundle a Kubernetes
+provider, pass it the same way as for a generic image:
+
+```Dockerfile
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init --version "${VERSION}" \
+      --model nvidia-jetson-agx-orin \
+      --provider k3s \
+      --provider-k3s-version v1.35.1+k3s1
+```
+
+`--fips`, `--trusted-boot`, `--skip-steps` and stage extensions (`-x`) all work identically.
+See [The Kairos Factory](/docs/reference/kairos-factory/) for the full flag reference.
+
+## Turn the OCI image into installable artifacts
+
+Once the image is built and pushed, feed it to [AuroraBoot](/docs/reference/auroraboot/) to
+produce partitions, ISOs or raw disk images. The generic AuroraBoot flow applies; Jetson-specific
+flashing steps (`Linux_for_Tegra` SDK, board configs, partition layouts) live on the per-board
+pages:
+
+- [Nvidia AGX Orin](/docs/installation/nvidia_agx_orin/) — eMMC flashing with the Jetson SDK.
+- [Nvidia Orin NX](/docs/installation/nvidia_orin_nx/) — NVMe flashing.
+- [Nvidia AGX Thor](/docs/installation/nvidia_agx_thor/) — Hadron-specific base and standard
+  Kairos install/upgrade flow.
+
+## GPU workloads on the cluster
+
+Building the image only gets you a bootable node. To let Kubernetes pods request
+`nvidia.com/gpu` on Thor, see [GPU Operator on Jetson AGX Thor](/hadron-docs/nvidia/thor-cluster/).
+For discrete NVIDIA GPUs on x86_64 (not Jetson), see
+[Discrete NVIDIA GPU on x86_64](/hadron-docs/nvidia/discrete-x86/).

--- a/docs/installation/edge-devices/nvidia_agx_orin.md
+++ b/docs/installation/edge-devices/nvidia_agx_orin.md
@@ -15,6 +15,12 @@ Nvidia AGX Orin currently only works with Ubuntu 22.04-based images.
 :::
 This page describes how to install Kairos on [Nvidia AGX Orin](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/) in the eMMC.
 
+:::tip Building your own AGX Orin image
+The image tags referenced below are examples. To build a fresh Kairos image for AGX Orin from
+Ubuntu 22.04, use [`kairos-init --model nvidia-jetson-agx-orin`](/docs/installation/nvidia-jetson-images/).
+That guide replaces the old `Dockerfile.nvidia`.
+:::
+
 
 ## Prerequisites
 

--- a/docs/installation/edge-devices/nvidia_agx_thor.md
+++ b/docs/installation/edge-devices/nvidia_agx_thor.md
@@ -85,3 +85,8 @@ From this point on, AGX Thor follows normal Kairos operations:
 - [Manual installation](../manual.md)
 - [Manual upgrades](../../upgrade/manual.md)
 - [Reset reference](../../reference/reset.md)
+
+## Deploy the GPU Operator
+
+Once the node is booted and joined to the cluster, wire up Kubernetes so pods can request
+`nvidia.com/gpu` — see [GPU Operator on Jetson AGX Thor](/hadron-docs/nvidia/thor-cluster/).

--- a/docs/installation/edge-devices/nvidia_agx_thor.md
+++ b/docs/installation/edge-devices/nvidia_agx_thor.md
@@ -11,6 +11,13 @@ import TabItem from '@theme/TabItem';
 
 This page describes the AGX Thor-specific image flow. After you have a Kairos Thor image, installation and lifecycle operations are the same as standard Kairos.
 
+:::tip Prefer a plain Ubuntu 24.04 base?
+The Ubuntu tab below shows the shortest path — a bare `kairos-init --model nvidia-jetson-thor`
+build. The [NVIDIA Jetson (build image)](/docs/installation/nvidia-jetson-images/) guide covers
+the same flow for all three Jetson models side by side; use it if you want to compare against
+AGX Orin / Orin NX.
+:::
+
 :::warning Minimum versions
 - `kairos-init` with Thor support requires `v0.9.0` or newer.
 - `AuroraBootISO` with Thor support requires ` v0.20.0` or newer.

--- a/docs/installation/edge-devices/nvidia_orin_nx.md
+++ b/docs/installation/edge-devices/nvidia_orin_nx.md
@@ -14,6 +14,12 @@ The Ubuntu versions supported on the Orin NX depend on the JetPack release. Chec
 :::
 This page describes how to install Kairos on an [Nvidia Orin NX](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/) on the NVMe.
 
+:::tip Building your own Orin NX image
+The image tags referenced below are examples. To build a fresh Kairos image for Orin NX from
+Ubuntu 22.04, use [`kairos-init --model nvidia-jetson-orin-nx`](/docs/installation/nvidia-jetson-images/).
+That guide replaces the old `Dockerfile.nvidia`.
+:::
+
 
 ## Prerequisites
 

--- a/docs/reference/kairos-factory.mdx
+++ b/docs/reference/kairos-factory.mdx
@@ -149,7 +149,7 @@ Here is a list of flags, explanation and what are the possible and default value
 | -v                         | Set version of the artifact that we are building                  | Any                        | None (REQUIRED) |
 | -l                         | Sets the log level                                                | info,warn,debug,trace      | info            |
 | -s                         | Sets the stage to run                                             | install, init, all         | all             |
-| -m                         | Sets the model                                                    | generic, rpi3, rpi4        | generic         |
+| -m                         | Sets the model — pulls in board-specific packages, kernels and cloud-configs. See [Supported device targets](#supported-device-targets). | generic, rpi3, rpi4, nvidia-jetson-agx-orin, nvidia-jetson-orin-nx, nvidia-jetson-thor | generic         |
 | -p / --provider            | Provider plugin name (repeatable for multiple providers)          | e.g. k3s, k0s              | None            |
 | --provider-&lt;NAME&gt;-version | Version for the given provider (e.g. `--provider-k3s-version`)     | Release tag from provider (e.g. k3s: [v1.35.1+k3s1](https://github.com/k3s-io/k3s/releases), k0s: [v1.35.1+k0s.1](https://github.com/k0sproject/k0s/releases)) | None            |
 | --provider-&lt;NAME&gt;-config  | Config file for the given provider (e.g. `--provider-k3s-config`)  | Path to config file        | None            |
@@ -169,6 +169,30 @@ You can provide a generic Dockerfile that gets all this values and passes them d
 :::info K8s versions
 When selecting a provider (e.g. with `--provider k3s`), you can pin the version using `--provider-k3s-version` or `--provider-k0s-version`. The value **must be an existing release tag** from the provider's release page (e.g. [k3s releases](https://github.com/k3s-io/k3s/releases) such as `v1.35.1+k3s1`, [k0s releases](https://github.com/k0sproject/k0s/releases) such as `v1.35.1+k0s.1`). If you omit the version, the provider plugin typically installs its default or latest. The Kairos provider for Kubernetes is included when you use a k8s provider.
 :::
+
+## Supported device targets
+
+The `--model` (`-m`) flag tells `kairos-init` which hardware it is building for. The default is
+`generic` — no board-specific packages, kernels or cloud-configs, suitable for x86_64 / arm64
+VMs, bare metal servers and cloud instances. Selecting a specific model pulls in the appropriate
+apt/dnf repos, kernel packages, cloud-configs and workarounds so the resulting image is bootable
+on that hardware without extra work in your Dockerfile.
+
+| `--model`                    | Target hardware                                                    | Build guide |
+|------------------------------|--------------------------------------------------------------------|-------------|
+| `generic` *(default)*        | x86_64 / arm64 VMs, bare metal servers, cloud instances            | This page   |
+| `rpi3`                       | Raspberry Pi 3                                                     | [RaspberryPi](/docs/installation/raspberry/) |
+| `rpi4`                       | Raspberry Pi 4                                                     | [RaspberryPi](/docs/installation/raspberry/) |
+| `nvidia-jetson-agx-orin`     | NVIDIA Jetson AGX Orin (L4T r36.x)                                 | [NVIDIA Jetson (build image)](/docs/installation/nvidia-jetson-images/) |
+| `nvidia-jetson-orin-nx`      | NVIDIA Jetson Orin NX (L4T r36.x)                                  | [NVIDIA Jetson (build image)](/docs/installation/nvidia-jetson-images/) |
+| `nvidia-jetson-thor`         | NVIDIA Jetson AGX Thor / T264 (L4T r38.x)                          | [NVIDIA Jetson (build image)](/docs/installation/nvidia-jetson-images/) |
+
+The Jetson build guide covers all three NVIDIA models in one place; per-board flashing and
+install steps stay on the existing device pages
+([AGX Orin](/docs/installation/nvidia_agx_orin/),
+[Orin NX](/docs/installation/nvidia_orin_nx/),
+[AGX Thor](/docs/installation/nvidia_agx_thor/)).
+
 ## Phases
 
 kairos-init is divided in 2 phases, one its the install phase which install all needed packages and binaries and the other is the init phase, which gets the system ready. This are the main parts of each phase:

--- a/hadron-docs/linux-firmware.md
+++ b/hadron-docs/linux-firmware.md
@@ -18,7 +18,7 @@ firmware files, so you can pick whichever way of consuming them fits your workfl
 
 1. **Firmware container images** (OCI images) — one image per firmware folder, meant to be copied
    on top of your Hadron image with a small `Dockerfile`. Use this to bake firmware into a custom
-   image, the same way the [NVIDIA drivers](nvidia-extension.md) page extends Hadron.
+   image, the same way the [NVIDIA drivers](nvidia/discrete-x86.md) page extends Hadron.
 2. **System extensions (sysexts)** — `*.sysext.raw` files that are loaded at boot by
    `systemd-sysext` and can be added/removed on a running system, without rebuilding the OS image.
    This is the same mechanism described in [Extending Hadron with extensions](expand-with-sysext.md)

--- a/hadron-docs/nvidia/_category_.json
+++ b/hadron-docs/nvidia/_category_.json
@@ -1,0 +1,10 @@
+{
+  "label": "NVIDIA on Hadron",
+  "position": 4,
+  "link": {
+    "type": "doc",
+    "id": "nvidia/index"
+  },
+  "collapsible": true,
+  "collapsed": true
+}

--- a/hadron-docs/nvidia/discrete-x86.md
+++ b/hadron-docs/nvidia/discrete-x86.md
@@ -1,23 +1,31 @@
 ---
-title: Nvidia drivers
-sidebar_position: 4
+title: "Discrete NVIDIA GPU on x86_64"
+sidebar_label: "Discrete GPU (x86_64)"
+sidebar_position: 2
 ---
 
-# Build a custom Hadron image with NVIDIA drivers
+# Build a custom Hadron image with NVIDIA drivers (x86_64)
 
-Hadron Linux is a musl-based, from-scratch distribution. NVIDIA's pre-built driver containers
-target specific glibc distributions (Ubuntu, RHEL, etc.) and do not support Hadron out of the
-box. The correct approach is to compile NVIDIA open kernel modules against the exact Hadron
-kernel version and bake them — along with the NVIDIA userspace tools and a glibc shim — into a
-custom OCI image.
+For discrete NVIDIA GPUs on x86_64. Hadron is musl-based and from-scratch, so NVIDIA's pre-built
+driver containers do not apply — the driver must be compiled from source against the exact Hadron
+kernel and baked into a custom OCI image. The [`kairos-io/hadron`](https://github.com/kairos-io/hadron)
+repository provides `examples/add-packages/Dockerfile.nvidia` which does exactly this.
 
-The [`kairos-io/hadron`](https://github.com/kairos-io/hadron) repository provides
-`examples/add-packages/Dockerfile.nvidia` which does exactly this.
+Read [the overview](index.md) first — it covers the driver-less GPU Operator model, the
+`v25.10.1` version pin and the shared validation steps referenced below.
+
+## Prerequisites
+
+- A node with a discrete NVIDIA GPU on x86_64.
+- Docker with `buildx`, or a GitHub Actions runner for cross-arch/CI builds.
+- A running Kairos Hadron cluster (see [Kairos Factory](/docs/reference/kairos-factory/)) whose
+  release matches the base image you build against.
+- Access to push the resulting image to a registry your nodes can pull from.
 
 ## Choosing the right base image
 
-The `hadron-extension` final stage uses `BASE_IMAGE` as its base. The right value depends on
-what you plan to do with the image:
+The `hadron-extension` final stage uses `BASE_IMAGE` as its base. The right value depends on what
+you plan to do with the image:
 
 | Use case | `BASE_IMAGE` |
 |---|---|
@@ -29,13 +37,14 @@ When upgrading a running node with the Kairos operator, the upgrade pod runs `ka
 `kairos-agent`; using it as the base will fail at upgrade time with
 `kairos-agent: command not found`.
 
-To find the correct full Kairos image tag for your running node:
+Find the correct full Kairos image tag for your running node:
 
 ```bash
 kairos-agent upgrade list-releases | grep hadron
 ```
 
 Example output:
+
 ```
 quay.io/kairos/hadron:v0.0.4-standard-amd64-generic-v4.0.3-k3s-v1.35.2-k3s1
 ```
@@ -53,16 +62,14 @@ Use that full image reference as your `BASE_IMAGE` + `BASE_IMAGE_TAG`.
 | `JOBS` | Parallelism for compilation (`$(nproc)` on native builds). |
 | `KERNEL_ARCH` | Kernel `ARCH` value — must be `x86_64` (not `amd64`) for x86_64 targets. |
 
-:::info
-`HADRON_VERSION` and `BASE_IMAGE_TAG` serve different purposes. `HADRON_VERSION` pins the
-toolchain (and thus the kernel version the modules are compiled against). `BASE_IMAGE_TAG` is
-the tag of the OS image layered into the final output. Keep `HADRON_VERSION` matching the
-Hadron flavor release (e.g. `v0.0.4`); `BASE_IMAGE_TAG` may be the longer Kairos release tag.
+:::info `HADRON_VERSION` vs `BASE_IMAGE_TAG`
+`HADRON_VERSION` pins the toolchain (and thus the kernel version the modules are compiled
+against). `BASE_IMAGE_TAG` is the tag of the OS image layered into the final output. Keep
+`HADRON_VERSION` matching the Hadron flavor release (e.g. `v0.0.4`); `BASE_IMAGE_TAG` may be the
+longer Kairos release tag.
 :::
 
 ## What the image contains
-
-The build produces a Kairos OS image with these additions on top of the base:
 
 | Component | Source | Purpose |
 |---|---|---|
@@ -77,11 +84,11 @@ The build produces a Kairos OS image with these additions on top of the base:
 
 :::info Why `nvidia-modprobe` and the udev rule are required
 
-The NVIDIA kernel modules load at boot, but on Hadron (a from-scratch distro) the standard
-distro udev rules for creating NVIDIA device nodes are not present. Without `nvidia-modprobe`
-being called after the modules load, `/dev/nvidia0`, `/dev/nvidia-uvm` and friends are never
-created. The result is that `nvidia-smi` starts but reports *"couldn't communicate with the
-NVIDIA driver"* even though `lsmod | grep nvidia` shows the modules as loaded.
+The NVIDIA kernel modules load at boot, but on Hadron the standard distro udev rules for
+creating NVIDIA device nodes are not present. Without `nvidia-modprobe` being called after the
+modules load, `/dev/nvidia0`, `/dev/nvidia-uvm` and friends are never created. `nvidia-smi`
+starts but reports *"couldn't communicate with the NVIDIA driver"* even though `lsmod | grep
+nvidia` shows the modules as loaded.
 
 The image installs two udev rules in `/etc/udev/rules.d/71-nvidia.rules`:
 
@@ -90,9 +97,9 @@ SUBSYSTEM=="module", ACTION=="add", KERNEL=="nvidia",     RUN+="/usr/bin/nvidia-
 SUBSYSTEM=="module", ACTION=="add", KERNEL=="nvidia_uvm", RUN+="/usr/bin/nvidia-modprobe -u"
 ```
 
-Do **not** combine the flags into a single `nvidia-modprobe -c 0 -u` call: `-u` means *"act
-on the UVM module instead of the GPU module"*, so it suppresses `/dev/nvidia0` creation
-entirely and the GPU stays inaccessible to userspace.
+Do **not** combine the flags into a single `nvidia-modprobe -c 0 -u` call: `-u` means *"act on
+the UVM module instead of the GPU module"*, so it suppresses `/dev/nvidia0` creation entirely
+and the GPU stays inaccessible to userspace.
 :::
 
 :::warning Hadron usr-merge trap when extending the image
@@ -233,12 +240,12 @@ public so your cluster nodes can pull it without credentials.
 
 ## Upgrading a running Kairos node with `NodeOpUpgrade`
 
-Use the Kairos operator to upgrade a node in-place. The operator creates a privileged pod on
-the target node that runs `kairos-agent` **from inside the container** — this is important
-because it creates the squashfs for the new active partition directly from the running container
-filesystem, preserving all symlinks (including `/boot/vmlinuz`) correctly. Running
-`kairos-agent upgrade --source oci:` directly on the host unpacks OCI layers separately and
-can break those symlinks, causing a GRUB boot failure (`invalid magic number`).
+Use the Kairos operator to upgrade a node in-place. The operator creates a privileged pod on the
+target node that runs `kairos-agent` **from inside the container** — this is important because it
+creates the squashfs for the new active partition directly from the running container filesystem,
+preserving all symlinks (including `/boot/vmlinuz`) correctly. Running `kairos-agent upgrade
+--source oci:` directly on the host unpacks OCI layers separately and can break those symlinks,
+causing a GRUB boot failure (`invalid magic number`).
 
 ```yaml
 apiVersion: operator.kairos.io/v1alpha1
@@ -257,7 +264,6 @@ spec:
 ```
 
 :::info Why `force: true` is required
-
 The operator compares the version string in `/etc/kairos-release` of the running node against
 the image. Because the custom NVIDIA image is based on the same Kairos release as the running
 node, the versions match and the operator exits with *"Up to date"* without writing anything.
@@ -271,7 +277,7 @@ kubectl apply -f nodeopupgrade.yaml
 kubectl get pods -A | grep upgrade
 ```
 
-The node will reboot once. After it comes back, verify NVIDIA is functional:
+The node reboots once. After it comes back, verify NVIDIA is functional:
 
 ```bash
 ssh kairos@<node-ip> "nvidia-smi"
@@ -281,9 +287,9 @@ Expected output shows the GPU name, driver version `580.126.20`, and temperature
 
 ## Installing the NVIDIA GPU Operator (driver-less mode)
 
-With NVIDIA kernel modules already in the OS image, install the GPU Operator with
-`driver.enabled=false` so it manages only the device plugin and feature discovery — not the
-driver:
+The [overview](index.md#driver-less-gpu-operator) explains why `driver.enabled=false` and pins
+the operator version. For discrete x86_64 the operator's own container toolkit is the correct
+choice, so `toolkit.enabled=true`:
 
 ```bash
 helm repo add nvidia https://helm.ngc.nvidia.com/nvidia && helm repo update
@@ -299,72 +305,27 @@ helm install gpu-operator nvidia/gpu-operator \
   --set nfd.enabled=true
 ```
 
-Keep `toolkit.enabled=true`: the toolkit container configures the host's containerd /
-CRI-O runtime to invoke the NVIDIA OCI hook for GPU containers. With drivers in the OS
-image, the toolkit no longer needs to *install* the driver (`driver.enabled=false`), but
-it still needs to wire up the runtime.
+Keep `toolkit.enabled=true`: the toolkit container configures the host's containerd / CRI-O
+runtime to invoke the NVIDIA OCI hook for GPU containers. With drivers in the OS image, the
+toolkit no longer needs to *install* the driver (`driver.enabled=false`), but it still needs to
+wire up the runtime.
 
-:::warning
-Use GPU Operator **v25.10.1**, not v26.x. Version 26 ships `nvidia-ctk` 1.19 which conflicts
-with the host toolkit version bundled in the Hadron image, causing CDI hook failures.
-:::
+## Validation
 
-Verify the GPU resource is registered:
+Follow the three-step validation in the [overview](index.md#validation): kubelet allocatable,
+`nvidia-smi` on the host, `cuda-vectoradd` pod. All three should pass on a healthy x86_64
+node.
 
-```bash
-kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.allocatable.nvidia\.com/gpu}{"\n"}{end}'
-```
+## Known issues
 
-A GPU-enabled node should show `1` (or more) in the `nvidia.com/gpu` column.
-
-## Validating end-to-end with a CUDA workload
-
-The operator's bundled `nvidia-cuda-validator` pod runs automatically as part of the
-`nvidia-operator-validator` init sequence and is a good first signal — if you see
-`nvidia-cuda-validator-xxxxx` in `gpu-operator` namespace with `STATUS: Completed`, basic
-CUDA compute already works.
-
-For an explicit, repeatable test deploy NVIDIA's `vectorAdd` sample requesting
-`nvidia.com/gpu: 1`:
-
-```bash
-kubectl apply -f - <<'EOF'
-apiVersion: v1
-kind: Pod
-metadata:
-  name: cuda-vectoradd
-spec:
-  restartPolicy: OnFailure
-  containers:
-  - name: cuda-vectoradd
-    image: nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubi8
-    resources:
-      limits:
-        nvidia.com/gpu: 1
-EOF
-
-kubectl wait --for=condition=Ready pod/cuda-vectoradd --timeout=120s || true
-kubectl logs cuda-vectoradd
-```
-
-Expected output:
-
-```
-[Vector addition of 50000 elements]
-Copy input data from the host memory to the CUDA device
-CUDA kernel launch with 196 blocks of 256 threads
-Copy output data from the CUDA device to the host memory
-Test PASSED
-Done
-```
-
-The pod will end up in `Completed` (it's a one-shot CUDA program). If it's stuck in
-`Pending` because nothing tolerates the GPU schedule, check that the worker carries the
-`nvidia.com/gpu=true` label and the `gpu-operator` daemonset pods on it are all
-`Running`.
-
-Clean up:
-
-```bash
-kubectl delete pod cuda-vectoradd
-```
+- **Cilium fails to schedule with `failed to add veth pair`** — the classic symptom of the
+  usr-merge trap described under [What the image contains](#what-the-image-contains). Rebuild the
+  image without a real `/usr/sbin/` directory in the builder stage.
+- **GPU pods fail with `stat /sbin/ldconfig: no such file or directory`** — `ldconfig` was not
+  shipped in the image, or was shipped as the wrapper script instead of `ldconfig.real`. See the
+  `ldconfig` admonition under [What the image contains](#what-the-image-contains).
+- **`nvidia-smi` reports "couldn't communicate with the NVIDIA driver"** — modules loaded but
+  `/dev/nvidia*` nodes never created. Verify the udev rules in `/etc/udev/rules.d/71-nvidia.rules`
+  and that `nvidia-modprobe` is on `PATH`.
+- **GPU Operator upgrade fails with `flag provided but not defined: -host-cuda-version`** —
+  someone bumped past `v25.10.x`. See the [version pin](index.md#gpu-operator-version-pin).

--- a/hadron-docs/nvidia/index.md
+++ b/hadron-docs/nvidia/index.md
@@ -1,0 +1,102 @@
+---
+title: "NVIDIA GPU support on Hadron"
+sidebar_label: "Overview"
+sidebar_position: 1
+---
+
+# NVIDIA GPU support on Hadron
+
+Hadron supports two NVIDIA GPU platforms, each with its own build and deploy flow. Both bake the
+kernel driver into the OS image (Hadron is musl-based and from-scratch, so NVIDIA's pre-built
+driver containers do not apply) and then run the [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/)
+in **driver-less mode** so Kubernetes can schedule `nvidia.com/gpu` workloads.
+
+## Which page do I need?
+
+| Your hardware | Follow |
+|---|---|
+| Discrete NVIDIA GPU on x86_64 (data-center, workstation) | [Discrete NVIDIA GPU on x86_64](discrete-x86.md) |
+| NVIDIA Jetson AGX Thor (Tegra SoC, ARM64) | Build the base image with [Nvidia AGX Thor](/docs/installation/nvidia_agx_thor/), then set up the cluster with [GPU Operator on Jetson Thor](thor-cluster.md) |
+| Older NVIDIA Jetson (Orin, Xavier, Nano) | Not currently covered — open an issue on [`kairos-io/kairos`](https://github.com/kairos-io/kairos/issues) |
+
+The two paths share a few pieces of infrastructure explained once here; the platform-specific
+pages assume you have read this overview.
+
+## What the two paths share
+
+### Driver-less GPU Operator
+
+Both platforms build the kernel driver **into the OS image** (open GPU kernel modules on x86,
+Tegra out-of-tree modules for Thor). This means the GPU Operator is installed with
+`driver.enabled=false` — it manages only the device plugin, feature discovery and (on x86) the
+container toolkit. It does **not** deploy a driver container.
+
+Consequence: an upgrade to a new NVIDIA driver version is a **Hadron image rebuild**, not a
+Kubernetes-side upgrade. Plan driver bumps like OS upgrades.
+
+### GPU Operator version pin
+
+Use **GPU Operator `v25.10.1`**. Do **not** upgrade to `v26.x`.
+
+`v26.x` ships `nvidia-device-plugin v0.19.x`, which bundles `nvidia-ctk` `1.19` and generates
+CDI specs referencing the `-host-cuda-version` flag introduced in `1.19`. Both the host
+`nvidia-ctk` on Thor (`1.18.1` from the r38.4 jetson repo) and the toolkit shipped by the
+operator's own container on x86 are still on `1.18.x`, so CDI hook execution fails with:
+
+```
+flag provided but not defined: -host-cuda-version
+```
+
+Stay on `v25.10.1` until NVIDIA bumps the jetson repo and the operator's toolkit image in
+lockstep.
+
+### Validation
+
+Once the OS image boots and the GPU Operator's daemonset pods are `Running`, both paths validate
+the same way:
+
+1. **Kubelet sees the GPU:**
+
+    ```bash
+    kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.allocatable.nvidia\.com/gpu}{"\n"}{end}'
+    ```
+
+    Expect `1` (or more) per GPU-enabled node.
+
+2. **`nvidia-smi` runs on the host:**
+
+    ```bash
+    ssh kairos@<node-ip> "nvidia-smi"
+    ```
+
+    Should print the GPU name, driver version and temperature.
+
+3. **CUDA compute works from a pod:**
+
+    ```bash
+    kubectl apply -f - <<'EOF'
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: cuda-vectoradd
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: cuda-vectoradd
+        image: nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0-ubi8
+        resources:
+          limits:
+            nvidia.com/gpu: 1
+    EOF
+
+    kubectl wait --for=condition=Ready pod/cuda-vectoradd --timeout=120s || true
+    kubectl logs cuda-vectoradd
+    ```
+
+    Expected tail: `Test PASSED`.
+
+    On Thor, run the equivalent [Thor-specific smoke pod](thor-cluster.md#validate) instead — the
+    Tegra path uses `runtimeClassName: nvidia` and NVIDIA's Thor CUDA image.
+
+The per-platform pages skip these generic checks and only spell out the platform-specific
+verification (driver version match, extra pod annotations, etc.).

--- a/hadron-docs/nvidia/index.md
+++ b/hadron-docs/nvidia/index.md
@@ -16,8 +16,9 @@ in **driver-less mode** so Kubernetes can schedule `nvidia.com/gpu` workloads.
 | Your hardware | Follow |
 |---|---|
 | Discrete NVIDIA GPU on x86_64 (data-center, workstation) | [Discrete NVIDIA GPU on x86_64](discrete-x86.md) |
-| NVIDIA Jetson AGX Thor (Tegra SoC, ARM64) | Build the base image with [Nvidia AGX Thor](/docs/installation/nvidia_agx_thor/), then set up the cluster with [GPU Operator on Jetson Thor](thor-cluster.md) |
-| Older NVIDIA Jetson (Orin, Xavier, Nano) | Not currently covered — open an issue on [`kairos-io/kairos`](https://github.com/kairos-io/kairos/issues) |
+| NVIDIA Jetson AGX Thor (Tegra SoC, ARM64) | Build the base image with [Nvidia AGX Thor](/docs/installation/nvidia_agx_thor/) (or the model-agnostic [NVIDIA Jetson build guide](/docs/installation/nvidia-jetson-images/)), then set up the cluster with [GPU Operator on Jetson Thor](thor-cluster.md) |
+| NVIDIA Jetson AGX Orin / Orin NX (L4T r36.x) | Build with [`kairos-init --model nvidia-jetson-*`](/docs/installation/nvidia-jetson-images/); flash per [AGX Orin](/docs/installation/nvidia_agx_orin/) or [Orin NX](/docs/installation/nvidia_orin_nx/). Cluster-side GPU Operator on these boards is not yet documented — open an issue on [`kairos-io/kairos`](https://github.com/kairos-io/kairos/issues) if you need it. |
+| Older NVIDIA Jetson (Xavier, Nano) | Not currently covered — open an issue on [`kairos-io/kairos`](https://github.com/kairos-io/kairos/issues) |
 
 The two paths share a few pieces of infrastructure explained once here; the platform-specific
 pages assume you have read this overview.

--- a/hadron-docs/nvidia/thor-cluster.md
+++ b/hadron-docs/nvidia/thor-cluster.md
@@ -1,0 +1,199 @@
+---
+title: "GPU Operator on Jetson AGX Thor"
+sidebar_label: "GPU Operator (Thor)"
+sidebar_position: 3
+---
+
+# GPU Operator on Hadron Thor (T264)
+
+Deploy the NVIDIA GPU Operator on a Hadron Jetson AGX Thor node so pods can request
+`nvidia.com/gpu` resources and run CUDA workloads. This page covers **only the cluster-side
+setup** — the host image itself is built separately, see
+[Nvidia AGX Thor](/docs/installation/nvidia_agx_thor/).
+
+Read [the overview](index.md) first — it explains the driver-less GPU Operator model, the
+`v25.10.1` pin (Thor is where the `nvidia-ctk 1.19` mismatch bites hardest) and the shared
+validation steps.
+
+## Prerequisites
+
+- Node booted from a Hadron Thor image built via
+  [Nvidia AGX Thor](/docs/installation/nvidia_agx_thor/), so the image ships:
+  - a build-from-scratch Tegra-compatible kernel with Tegra out-of-tree modules baked in,
+  - `nvidia-container-toolkit 1.18.1` (from NVIDIA's r38.4 jetson `.deb` repo),
+  - CSV files from `nvidia-l4t-init` under `/etc/nvidia-container-runtime/host-files-for-container.d/`
+    (`drivers.csv`, `devices.csv`, `l4t.csv`),
+  - `nvidia-cdi-refresh.service` enabled (auto-runs `nvidia-ctk cdi generate` at boot and writes
+    `/var/run/cdi/nvidia.yaml`).
+- `sudo nvidia-smi` on the host prints `NVIDIA Thor`.
+- k3s installed with the NVIDIA runtime configured (containerd CDI enabled).
+- `helm` available on your workstation.
+
+## Why the version pin bites harder on Thor
+
+The host on Thor ships `nvidia-ctk 1.18.1` — the latest release currently in NVIDIA's r38.4
+jetson `.deb` repo. If NVIDIA has not yet published `1.19.x` for jetson when you read this,
+`v26.x` of the operator **will** trip the `flag provided but not defined: -host-cuda-version`
+CDI hook error. On x86 you can at least upgrade the host toolkit yourself; on Thor you are tied
+to what the jetson repo carries.
+
+| Component                | Version | Source                        |
+|--------------------------|---------|-------------------------------|
+| Host `nvidia-ctk`        | 1.18.1  | r38.4 jetson repo (`.deb`)    |
+| device-plugin container  | v0.18.1 | GPU Operator helm chart       |
+| `nvidia-ctk` inside plugin | 1.18.1 | bundled in plugin image       |
+
+Use `v25.10.1`. Do not use `v26.x` until NVIDIA bumps the jetson repo to `1.19+`.
+
+## Install
+
+```bash
+helm repo add nvidia https://nvidia.github.io/gpu-operator
+helm repo update nvidia
+
+cat > /tmp/gpu-operator-values.yaml <<'EOF'
+# Host already ships nvidia-container-toolkit (deb from r38.4 jetson repo).
+toolkit:
+  enabled: false
+
+# Tegra OOT driver is built into the kernel, not deployed by the operator.
+driver:
+  enabled: false
+
+# Tegra single-GPU pure-CSV path: when only one GPU is present, the device-plugin
+# falls back to "pure CSV" device-spec generation with an empty UUID. The default
+# UUID-based namer then returns "" -> "no names defined" -> pod start error.
+# Override to index naming.
+devicePlugin:
+  env:
+    - name: DEVICE_ID_STRATEGY
+      value: index
+EOF
+
+helm upgrade --install gpu-operator nvidia/gpu-operator \
+  -n gpu-operator --create-namespace \
+  --version v25.10.1 \
+  -f /tmp/gpu-operator-values.yaml
+```
+
+Compared to the x86 values (`toolkit.enabled=true`, no `devicePlugin.env` override), Thor
+disables the toolkit (host provides it) and forces the device-plugin's naming strategy.
+
+## Post-install daemonset patch
+
+The device-plugin container needs to read the host CSV files at
+`/etc/nvidia-container-runtime/host-files-for-container.d/` (drivers.csv, devices.csv, l4t.csv).
+The chart doesn't expose `extraVolumes` / `extraVolumeMounts` on `devicePlugin`, and the
+controller resets `NVIDIA_DRIVER_ROOT=/`, so the alternative of pointing driver-root at the
+existing `/host` mount doesn't survive reconciliation.
+
+Bind-mount the CSV directory into the plugin container directly:
+
+```bash
+kubectl patch daemonset nvidia-device-plugin-daemonset -n gpu-operator --type=json -p='[
+  {"op":"add","path":"/spec/template/spec/volumes/-","value":{"name":"nv-csv","hostPath":{"path":"/etc/nvidia-container-runtime/host-files-for-container.d"}}},
+  {"op":"add","path":"/spec/template/spec/containers/0/volumeMounts/-","value":{"name":"nv-csv","mountPath":"/etc/nvidia-container-runtime/host-files-for-container.d","readOnly":true}}
+]'
+```
+
+:::warning The patch does not survive `helm upgrade`
+The patch persists across plugin pod restarts but **is reverted if you `helm upgrade` the
+chart**. Re-apply after every helm upgrade.
+:::
+
+## Validate
+
+Start with the [shared validation](index.md#validation) (allocatable count, host `nvidia-smi`,
+plus the Thor smoke pod below instead of `cuda-vectoradd`). Then:
+
+```bash
+# Wait for the device-plugin pod to become Ready
+kubectl get pod -n gpu-operator -l app=nvidia-device-plugin-daemonset -w
+
+# GPU resource registered with kubelet
+kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.allocatable.nvidia\.com/gpu}{"\n"}{end}'
+# Expected: <node-name>    1
+
+# Quick describe view
+kubectl describe node | grep "nvidia.com/gpu"
+```
+
+### Smoke-test pod
+
+```yaml
+# /tmp/gpu-smi.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-smi
+spec:
+  restartPolicy: Never
+  runtimeClassName: nvidia
+  containers:
+  - name: smi
+    image: ubuntu:24.04
+    command: ["bash", "-c", "nvidia-smi"]
+    resources:
+      limits:
+        nvidia.com/gpu: 1
+```
+
+```bash
+kubectl apply -f /tmp/gpu-smi.yaml
+kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/gpu-smi --timeout=2m
+kubectl logs gpu-smi
+```
+
+Expected:
+
+```
+NVIDIA-SMI 580.00     Driver Version: 580.00     CUDA Version: 13.0
+0  NVIDIA Thor    Off  |   00000000:01:00.0 Off
+```
+
+## Optional: gpu-operator-free path
+
+The image enables `nvidia-cdi-refresh.service`, which auto-runs `nvidia-ctk cdi generate` at boot
+and writes `/var/run/cdi/nvidia.yaml`. For workloads that don't need k8s scheduling on
+`nvidia.com/gpu`, skip the device-plugin entirely and use a pod with `runtimeClassName: nvidia`
++ `NVIDIA_VISIBLE_DEVICES=all`:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gpu-direct
+spec:
+  restartPolicy: Never
+  runtimeClassName: nvidia
+  containers:
+  - name: smi
+    image: ubuntu:24.04
+    command: ["bash", "-c", "nvidia-smi"]
+    env:
+    - name: NVIDIA_VISIBLE_DEVICES
+      value: all
+    - name: NVIDIA_DRIVER_CAPABILITIES
+      value: all
+```
+
+This bypasses the device-plugin entirely. Useful for one-off jobs or when you don't want
+gpu-operator overhead. Caveat: kube-scheduler has no visibility into GPU consumption, so
+co-tenancy isn't enforced.
+
+## Known issues
+
+- **`nvidia-dcgm-exporter` crash-loops.** DCGM doesn't support Tegra. Disable via helm
+  `dcgmExporter.enabled=false` if the noise bothers you.
+- **`gpu-feature-discovery` reports `nvidia.com/gpu.family=undefined` and
+  `nvidia.com/gpu.mode=unknown`.** Cosmetic. NVML on Tegra returns `Not Supported` for several
+  queries.
+- **gpu-operator's official platform-support page states Jetson is not supported.** The recipe
+  above works because Thor's PCIe-attached GPU is close enough to a discrete GPU shape that the
+  device-plugin's pure-CSV fallback functions once the namer + CSV mount are corrected. Do not
+  expect NVIDIA support if something breaks — file issues on
+  [`kairos-io/kairos`](https://github.com/kairos-io/kairos/issues) instead.
+- **CDI hook fails with `flag provided but not defined: -host-cuda-version`.** Someone bumped
+  the chart past `v25.10.x`. See the [version pin](index.md#gpu-operator-version-pin).
+- **Device-plugin pod loses its CSV mount after a `helm upgrade`.** Re-apply the
+  [post-install patch](#post-install-daemonset-patch).

--- a/netlify.toml
+++ b/netlify.toml
@@ -27,6 +27,16 @@ to = "/quickstart/"
 status = 302
 
 [[redirects]]
+from = "/hadron-docs/nvidia-extension"
+to = "/hadron-docs/nvidia/discrete-x86/"
+status = 301
+
+[[redirects]]
+from = "/hadron-docs/nvidia-extension/"
+to = "/hadron-docs/nvidia/discrete-x86/"
+status = 301
+
+[[redirects]]
 from = "/docs/operator"
 to = "/operator-docs/"
 status = 302


### PR DESCRIPTION
Closes the docs side of kairos-io/kairos#4064.

The ticket originally suggested consolidating all NVIDIA-on-Hadron docs into one page. Once I actually laid the two flows next to each other it stopped making sense — discrete NVIDIA GPU on x86_64 and Jetson AGX Thor are genuinely different hardware paths with different install shapes, different driver stories, and different failure modes. Forcing them into one page just produced a decision tree pretending to be prose.

So instead of one page, a small `nvidia/` folder:

- `nvidia/index.md` — landing page. Decision matrix (which hardware → which page) and the parts that actually are shared: the driver-less GPU Operator model, the `v25.10.1` pin driven by the `nvidia-ctk 1.19` mismatch, and the 3-step validation shape (allocatable count, host `nvidia-smi`, `cuda-vectoradd`).
- `nvidia/discrete-x86.md` — the old `nvidia-extension.md` content, x86-specific, slimmed to drop what moved into the overview.
- `nvidia/thor-cluster.md` — the Thor cluster-side GPU Operator recipe, pulled out of `kairos-io/hadron/examples/add-packages/thor-gpu-operator.md`. Covers `toolkit=false + driver=false + DEVICE_ID_STRATEGY=index`, the daemonset CSV bind-mount patch, and the gpu-operator-free path.
- `nvidia/_category_.json` — folder metadata, `label: "NVIDIA on Hadron"`, `position: 4`, root doc points at the overview.

Along with:

- `hadron-docs/nvidia-extension.md` deleted.
- `hadron-docs/linux-firmware.md` cross-link fixed.
- `docs/installation/edge-devices/nvidia_agx_thor.md` now points at the new Thor cluster page for the GPU Operator step.
- `netlify.toml` — 301 from `/hadron-docs/nvidia-extension/` to the new discrete-x86 page so existing links keep working.

`npm run build` is clean.

Follow-up not in this PR, tracked back on the parent ticket: delete or stub the recipe file in `kairos-io/hadron` once this merges, and run the remaining #4064 verification steps on current Hadron for both paths.