### PR TITLE
docs(operator): add Helm and Kustomize install.yaml installation methods

### DIFF
--- a/operator-docs/installation.md
+++ b/operator-docs/installation.md
@@ -6,29 +6,109 @@ date: 2025-07-25
 description: Deploy and remove the Kairos operator on your Kubernetes cluster
 ---
 
-## Deploying the operator
+## Helm (recommended)
 
-To deploy the operator, you can use kubectl (provided that the `git` command is available):
+The operator publishes a Helm chart on each release via GitHub Pages and the GHCR OCI registry.
+
+### From the Helm repository
 
 ```bash
-# Using GitHub URL
-kubectl apply -k https://github.com/kairos-io/kairos-operator/config/default
+helm repo add kairos-operator https://kairos-io.github.io/kairos-operator/charts
+helm repo update
+helm install kairos-operator kairos-operator/kairos-operator \
+  --namespace kairos-operator --create-namespace
+```
 
-# Or using local directory (if you have the operator checked out)
-kubectl apply -k config/default
+### From the OCI registry
+
+```bash
+helm install kairos-operator \
+  oci://ghcr.io/kairos-io/helm-charts/kairos-operator \
+  --version 0.1.0 \
+  --namespace kairos-operator --create-namespace
+```
+
+### Key values
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `image.operator.tag` | Chart `appVersion` | Operator image tag |
+| `image.nodeLabeler.tag` | Chart `appVersion` | Node-labeler image tag |
+| `leaderElect` | `true` | Disable for single-replica dev installs |
+| `toolImage` | *(built-in)* | Override `auroraboot` image — useful for air-gapped environments |
+| `buildahImage` | *(built-in)* | Override `buildah` image — useful for air-gapped environments |
+| `sentinelImage` | *(built-in)* | Image for the reboot sentinel container (NodeOp `rebootOnSuccess` flow). Only needs `sh` + `tee`; defaults to `NodeOp.spec.image`, then `busybox:latest`. Override for air-gapped environments. |
+| `nodeops.defaultImage` | `busybox:latest` | Fallback image for NodeOp Jobs |
+| `tolerations` | control-plane + etcd | Scheduling tolerations for the operator Deployment |
+
+```bash
+helm install kairos-operator kairos-operator/kairos-operator \
+  --namespace kairos-operator --create-namespace \
+  --set leaderElect=true \
+  --set toolImage=my-registry.example.com/auroraboot:v0.24.0 \
+  --set sentinelImage=my-registry.example.com/busybox:latest
+```
+
+### Upgrading
+
+```bash
+helm repo update
+helm upgrade kairos-operator kairos-operator/kairos-operator \
+  --namespace kairos-operator --reuse-values
+```
+
+:::note
+CRDs are placed in the `crds/` directory of the chart. Helm installs them on first install but **never upgrades or deletes them** on `helm upgrade` or `helm uninstall`. To upgrade CRDs, apply them manually:
+
+```bash
+kubectl apply -f https://github.com/kairos-io/kairos-operator/releases/latest/download/install.yaml
+```
+:::
+
+### Removing
+
+```bash
+helm uninstall kairos-operator --namespace kairos-operator
+```
+
+CRDs survive uninstall by design. To remove them completely:
+
+```bash
+kubectl delete crd \
+  osartifacts.build.kairos.io \
+  nodeops.operator.kairos.io \
+  nodeopupgrades.operator.kairos.io
+```
+
+---
+
+## Kustomize / plain kubectl
+
+Each release publishes a pre-built `install.yaml` as a GitHub Release asset:
+
+```bash
+# Latest release
+kubectl apply -f https://github.com/kairos-io/kairos-operator/releases/latest/download/install.yaml
+
+# Pin to a specific version
+kubectl apply -f https://github.com/kairos-io/kairos-operator/releases/download/v0.1.0/install.yaml
+```
+
+Alternatively, render from source using Kustomize directly (requires `git`):
+
+```bash
+kubectl apply -k https://github.com/kairos-io/kairos-operator/config/default
 ```
 
 When the operator starts, it will automatically detect Kairos nodes and label them with `kairos.io/managed: true`. This label can be used to target Kairos nodes specifically in hybrid clusters.
 
-## Removing the operator
+### Removing
 
 ```bash
-# Using GitHub URL
-kubectl delete -k https://github.com/kairos-io/kairos-operator/config/default
-
-# Or using local directory
-kubectl delete -k config/default
+kubectl delete -f https://github.com/kairos-io/kairos-operator/releases/latest/download/install.yaml
 ```
+
+---
 
 ## Installing via Bundle
 
@@ -44,7 +124,7 @@ This will automatically deploy the operator during the node initialization proce
 
 ### Removing the Bundle Installation
 
-To remove the operator installed via bundle, you need to delete the `kairos-operator.yaml` file from the appropriate location:
+To remove the operator installed via bundle, delete the `kairos-operator.yaml` file from the appropriate location:
 
 - **k0s**: `/var/lib/k0s/manifests/kairos-operator/`
 - **k3s**: `/var/lib/rancher/k3s/server/manifests/`

--- a/operator-docs/installation.md
+++ b/operator-docs/installation.md
@@ -44,7 +44,7 @@ helm install kairos-operator \
 ```bash
 helm install kairos-operator kairos-operator/kairos-operator \
   --namespace kairos-operator --create-namespace \
-  --set leaderElect=true \
+  --set leaderElect=false \
   --set toolImage=my-registry.example.com/auroraboot:v0.24.0 \
   --set sentinelImage=my-registry.example.com/busybox:latest
 ```


### PR DESCRIPTION
## Summary

- Adds Helm as the recommended installation method (Helm repo + OCI registry)
- Adds key values table covering `leaderElect`, `toolImage`, `buildahImage`, `sentinelImage`, `nodeops.defaultImage`, `tolerations`
- Adds CRD upgrade warning (`crds/` dir — Helm never upgrades/deletes them)
- Adds pre-built `install.yaml` from GitHub Release assets as the primary Kustomize path (no `git` required); keeps `kubectl apply -k` as alternative
- Removes stale statement that no Helm chart exists
- Restructures page with clear sections and removal instructions per method

## Related

Depends on / tracks: kairos-io/kairos-operator#137