### PR TITLE
docs(netboot): document in-RAM boot mode

### DIFF
--- a/docs/installation/netboot.md
+++ b/docs/installation/netboot.md
@@ -67,6 +67,15 @@ destroys all data on the selected disk.
 With AuroraBoot, put the same options in `netboot.cmdline`. With another PXE
 server, add them to the kernel command line in its boot entry.
 
+Because in-RAM mode does not install the system, provide [cloud
+config](/docs/reference/configuration) on every boot. This is especially
+important on the first boot, when the machine needs user data such as login
+credentials. Bundle the config with the boot artifacts, use a supported metadata
+source, or add `kairos.config_url=<URL>` to the kernel command line to fetch it
+from a central server. `kairos.config_url` is particularly useful with PXE
+because the server can keep both the boot configuration and machine
+configuration centralized.
+
 An in-RAM boot is reported as `active_boot`, so both of these sentinel files
 exist after immucore finishes:
 

--- a/docs/installation/netboot.md
+++ b/docs/installation/netboot.md
@@ -14,6 +14,76 @@ The recommended way to do this is with [AuroraBoot](/docs/reference/auroraboot),
 
 Generic hardware-based netboot setup (PXE BIOS configuration, DHCP, etc.) is out of scope for this document.
 
+## Run Kairos from RAM with local persistent data
+
+The in-RAM workflow is useful for machines that load the Kairos root filesystem
+into memory from live media or PXE, but still need machine-specific
+configuration and persistent data on a local disk. The machine does not need
+`COS_STATE` or `COS_ACTIVE` partitions. It mounts:
+
+- `COS_OEM` at `/oem` for cloud config and user data
+- `COS_PERSISTENT` at `/usr/local` for persistent state
+
+Add a `kairos.ram.*` option to the kernel command line to select this workflow.
+Use the bare `kairos.ram` option if you do not need any of the partition
+options:
+
+```text
+kairos.ram
+```
+
+For first boot on an empty disk, let Kairos create the local partitions:
+
+```text
+kairos.ram.create_partitions
+```
+
+Kairos selects the largest eligible empty disk. Removable media, CD-ROMs, and
+virtual block devices such as loop and device-mapper devices are excluded. To
+select a disk yourself, pass its path:
+
+```text
+kairos.ram.create_partitions=/dev/vda
+```
+
+The default `COS_OEM` size is 64 MiB. `COS_PERSISTENT` uses the rest of the
+disk. Override either size with a plain integer in MiB:
+
+```text
+kairos.ram.create_partitions=/dev/vda kairos.ram.oem=128 kairos.ram.persistent=10240
+```
+
+If one of the partitions already exists, Kairos keeps it and creates only the
+missing partition. Kairos refuses to repartition a disk that contains unrelated
+partitions unless you add `kairos.ram.wipe`.
+
+:::danger
+
+`kairos.ram.wipe` allows Kairos to replace an existing partition table and
+destroys all data on the selected disk.
+
+:::
+
+With AuroraBoot, put the same options in `netboot.cmdline`. With another PXE
+server, add them to the kernel command line in its boot entry.
+
+An in-RAM boot is reported as `active_boot`, so both of these sentinel files
+exist after immucore finishes:
+
+```text
+/run/cos/active_mode
+/run/cos/in_ram_mode
+```
+
+Use `/run/cos/in_ram_mode` when a script must distinguish an in-RAM root
+filesystem from a regular active boot:
+
+```bash
+if [ -e /run/cos/in_ram_mode ]; then
+  echo "Kairos is running from RAM"
+fi
+```
+
 ## Use AuroraBoot
 
 ```bash

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -58,6 +58,23 @@ Initramfs can be instructed to drop a shell in various phases of the boot proces
 - `rd.break=pre-mount rd.shell`: Drops a shell before setting up mount points.
 - `rd.break=pre-pivot rd.shell`: Drops a shell before switch-root
 
+## In-RAM boot failures
+
+See [Run Kairos from RAM with local persistent data](/docs/installation/netboot#run-kairos-from-ram-with-local-persistent-data)
+for the supported kernel options and disk-selection rules.
+
+In-RAM mode stops before cloud config runs when `COS_OEM` or
+`COS_PERSISTENT` is missing and partition creation is not enabled. It also
+stops when the selected disk is unavailable, the requested sizes are invalid,
+or an existing partition table requires explicit wipe consent.
+
+Immucore prints a full-screen error on every available console with the failed
+condition and the kernel option needed to correct it. On systemd systems, press
+any key to reboot immediately. With no input, the machine reboots after 90
+seconds so boot assessment records a failed boot. On non-systemd systems,
+immucore prints the message and the boot fails without the timed reboot. Check
+`/run/immucore/` for the full immucore logs on the next boot.
+
 ## Disable immutability
 
 It is possible to disable immutability by adding `rd.cos.debugrw` to the kernel boot commands.


### PR DESCRIPTION
## Summary

- document the `kairos.ram.*` kernel options and disk safety rules
- document the `active_mode` and `in_ram_mode` sentinels
- add troubleshooting guidance for immucore failure screens and reboot behavior

Requested in kairos-io/immucore#601.

## Validation

- `npm test` (11 tests pass)
- `git diff --check`

The Docusaurus build could not run locally because this environment returned HTTP 403 for required npm package tarballs.