### PR TITLE
docs(nvidia): explain Thor QSPI lifecycle

### DIFF
--- a/docs/installation/edge-devices/nvidia-jetson-images.md
+++ b/docs/installation/edge-devices/nvidia-jetson-images.md
@@ -26,7 +26,7 @@ replacement.
 |--------------------------|-------------------------------------------|------------|-------------------|
 | `nvidia-jetson-agx-orin` | [Jetson AGX Orin](/docs/installation/nvidia_agx_orin/)   | r36.x      | `ubuntu:22.04`    |
 | `nvidia-jetson-orin-nx`  | [Jetson Orin NX](/docs/installation/nvidia_orin_nx/)     | r36.x      | `ubuntu:22.04`    |
-| `nvidia-jetson-thor`     | [Jetson AGX Thor](/docs/installation/nvidia_agx_thor/)   | r38.x      | `ubuntu:24.04` or Hadron |
+| `nvidia-jetson-thor`     | [Jetson AGX Thor](/docs/installation/nvidia_agx_thor/)   | r39.2      | `ubuntu:24.04` or Hadron |
 
 For the full list of `--model` values (including `generic`, `rpi3`, `rpi4`) see
 [The Kairos Factory](/docs/reference/kairos-factory/#supported-device-targets).
@@ -112,6 +112,21 @@ For any of the Jetson models, `kairos-init`:
   cloud-config (disables `nv-l4t-boot-fw-update-in-preinstall`, sets up the Tegra rootfs prep,
   etc.).
 - Enables the required systemd services for the board.
+
+For Thor, the model also keeps QSPI boot firmware aligned with the image's L4T release:
+
+- The current Thor L4T pin and its matching UEFI capsule are installed together. Renovate
+  tracks new Thor L4T releases in `kairos-init` so the pair is updated together.
+- The live initramfs omits the proprietary NVIDIA drivers. This lets the installer boot on
+  boards with older, updatable QSPI firmware.
+- The same version check runs after installation and after every OCI upgrade. When the board
+  firmware is older, Kairos stages the capsule on the EFI System Partition and UEFI applies
+  it on the next boot. Matching versions are left unchanged.
+- A board with firmware newer than the image is rejected because UEFI capsules cannot
+  downgrade firmware. Firmware older than L4T 38.0 requires a USB host flash.
+
+See [Nvidia AGX Thor](/docs/installation/nvidia_agx_thor/#qspi-firmware-compatibility) for the
+full compatibility and lifecycle behavior.
 
 None of this needs to be written by hand — the flag pulls in everything the old
 `Dockerfile.nvidia` used to do, and stays current with L4T releases as `kairos-init` is

--- a/docs/installation/edge-devices/nvidia_agx_thor.md
+++ b/docs/installation/edge-devices/nvidia_agx_thor.md
@@ -49,7 +49,7 @@ docker build -f Dockerfile.Thor -t quay.io/myrepo/nvidia:v1.0.0 .
 Now pass it through `kairos-init` with the Thor model as mentioned in the [Kairos factory](../../reference/kairos-factory.mdx) docs. The key requirement is to specify `--model nvidia-jetson-thor`:
 
 ```Dockerfile
-FROM quay.io/kairos/kairos-init:v0.9.0 AS kairos-init
+FROM quay.io/kairos/kairos-init:{{< KairosInitVersion >}} AS kairos-init
 
 FROM quay.io/myrepo/nvidia:v1.0.0
 ARG VERSION=1.0.0
@@ -69,7 +69,7 @@ Now pass it through `kairos-init` with the Thor model as mentioned in the [Kairo
 
 
 ```Dockerfile
-FROM quay.io/kairos/kairos-init:v0.9.0 AS kairos-init
+FROM quay.io/kairos/kairos-init:{{< KairosInitVersion >}} AS kairos-init
 
 FROM ubuntu:24.04
 ARG VERSION=1.0.0
@@ -84,11 +84,35 @@ RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init /kairos
 
 Build the ISO with AuroraBoot as usual, using your Thor kairosified image. For AuroraBoot usage, see [AuroraBoot reference](../../reference/auroraboot.md).
 
-Boot from the ISO as in a normal Kairos workflow.
+Boot from the ISO as in a normal Kairos workflow. The Thor live image omits the proprietary
+NVIDIA drivers from its initramfs so it can boot when the board has older, but still
+updatable, QSPI firmware.
+
+## QSPI firmware compatibility
+
+Thor boot firmware and the L4T release in the Kairos image must match. `kairos-init` pins a
+release-matched L4T version for the Thor model and includes the corresponding UEFI capsule.
+The pin is updated with new Thor L4T releases. Set `L4T_VERSION` while running `kairos-init`
+only when you deliberately build the complete image for another matching L4T release.
+
+During installation and OCI upgrades, Kairos compares the board firmware reported by UEFI
+ESRT with the image's `nvidia-l4t-bootloader` version:
+
+- If the versions match, installation or upgrade continues without changing the firmware.
+- If the board firmware is older, Kairos stages the image's capsule on the EFI System
+  Partition. UEFI applies it on the next boot before Linux starts.
+- If the board firmware is newer, installation or upgrade stops. UEFI capsules cannot
+  downgrade QSPI firmware. Build a Kairos image for the board's L4T release or fully reflash
+  the board.
+- Firmware older than L4T 38.0 cannot be updated in-band and requires a USB host flash.
+
+Do not interrupt the next boot after a capsule has been staged. Firmware update progress is
+shown by the board firmware before Kairos starts.
 
 ## Install, upgrade, and reset
 
-From this point on, AGX Thor follows normal Kairos operations:
+AGX Thor follows normal Kairos operations, with the QSPI compatibility check above running
+after both installation and upgrades:
 - [Manual installation](../manual.md)
 - [Manual upgrades](../../upgrade/manual.md)
 - [Reset reference](../../reference/reset.md)


### PR DESCRIPTION
## Summary

- update the Thor L4T family to r39.2 and use the current kairos-init version shortcode
- document live ISO behavior and the install/upgrade QSPI capsule flow
- explain matching, forward-update, no-downgrade, and pre-r38 USB flash cases

Follow-up to kairos-io/kairos#4228 and kairos-io/kairos-init#411.

## Verification

- `npm test` (11 tests passed)
- `git diff --check`

`npm run typecheck` and `npm run build` could not run locally because repeated `npm ci` attempts left the locked TypeScript package empty in this environment (`tsc: not found`). CI remains the full build check.