### PR TITLE
:book: docs: use a consistent name for the cloud config file

### DIFF
--- a/docs/examples/airgap.md
+++ b/docs/examples/airgap.md
@@ -57,7 +57,7 @@ $ docker save images-bundle -o data/bundle.tar
 
 Now that we have created the bundle, we can use it to build an offline ISO for the airgap installation.
 
-1. Create a cloud config for the ISO and save it as config.yaml. The config.yaml file should contain your cloud configuration for Kairos and is used to set up the system when it is installed. An example can be:
+1. Create a cloud config for the ISO and save it as cloud-config.yaml. The cloud-config.yaml file should contain your cloud configuration for Kairos and is used to set up the system when it is installed. An example can be:
 ```yaml
 #cloud-config
 
@@ -93,7 +93,7 @@ IMAGE={{< OCI variant="standard" >}}
 
 docker pull $IMAGE
 
-docker run -v $PWD/config.yaml:/config.yaml \
+docker run -v $PWD/cloud-config.yaml:/cloud-config.yaml \
              -v $PWD/build:/tmp/auroraboot \
              -v /var/run/docker.sock:/var/run/docker.sock \
              -v $PWD/data:/tmp/data \
@@ -102,7 +102,7 @@ docker run -v $PWD/config.yaml:/config.yaml \
              --set "disable_netboot=true" \
              --set "container_image=oci:$IMAGE" \
              --set "iso.overlay_iso=/tmp/data" \
-             --cloud-config /config.yaml \
+             --cloud-config /cloud-config.yaml \
              --set "state_dir=/tmp/auroraboot"
 ```
 

--- a/docs/examples/virtual-box.md
+++ b/docs/examples/virtual-box.md
@@ -41,7 +41,7 @@ generateEfiKeys() {
 
 generateConfig() {
   mkdir -p $OUTDIR/config
-  cat << EOF > "$OUTDIR/config/config.yaml"
+  cat << EOF > "$OUTDIR/config/cloud-config.yaml"
 #cloud-config
 
 users:

--- a/docs/installation/automated.md
+++ b/docs/installation/automated.md
@@ -53,7 +53,7 @@ p2p:
 The token `p2p.network_token` is a base64 encoded string which
 contains an [`edgevpn` token](https://github.com/mudler/edgevpn/blob/master/docs/content/en/docs/Concepts/Token/_index.md). For more information, [check out the architecture section](/docs/architecture/network).
 
-Save this file as `cloud_init.yaml`, then create an ISO with the following steps:
+Save this file as `cloud-config.yaml`, then create an ISO with the following steps:
 
 1. Create a new directory and navigate to it:
 ```bash
@@ -63,7 +63,7 @@ $ cd build
 1. Create empty `meta-data` and copy your config as `user-data`:
 ```bash
 $ touch meta-data
-$ cp -rfv cloud_init.yaml user-data
+$ cp -rfv cloud-config.yaml user-data
 ```
 1. Use `mkisofs` to create the ISO file:
 ```bash
@@ -109,14 +109,14 @@ We can use [AuroraBoot](/docs/reference/auroraboot) to handle the the ISO build 
 $ IMAGE=<scheme://host[:port]/path[:tag]>
 $ docker pull $IMAGE
 # Build the ISO
-$ docker run -v $PWD/cloud_init.yaml:/cloud_init.yaml \
+$ docker run -v $PWD/cloud-config.yaml:/cloud-config.yaml \
                     -v $PWD/build:/tmp/auroraboot \
                     -v /var/run/docker.sock:/var/run/docker.sock \
                     --rm -ti quay.io/kairos/auroraboot \
                     --set container_image=oci:$IMAGE \
                     --set "disable_http_server=true" \
                     --set "disable_netboot=true" \
-                    --cloud-config /cloud_init.yaml \
+                    --cloud-config /cloud-config.yaml \
                     --set "state_dir=/tmp/auroraboot"
 # Artifacts are under build/
 $ sudo ls -liah build/iso
@@ -137,7 +137,7 @@ $ mkdir -p files-iso/boot/grub2
 $ wget https://raw.githubusercontent.com/kairos-io/packages/main/packages/livecd/grub2/config/grub_live_bios.cfg -O files-iso/boot/grub2/grub.cfg
 
 # Copy the config file
-$ cp -rfv cloud_init.yaml files-iso/cloud_config.yaml
+$ cp -rfv cloud-config.yaml files-iso/cloud-config.yaml
 # Pull the image locally
 $ docker pull $IMAGE
 # Optionally, modify the image here!
@@ -150,7 +150,7 @@ $ docker run -v $PWD:/cOS -v /var/run/docker.sock:/var/run/docker.sock -i --rm q
 </Tabs>
 
 :::tip Cloud config
-In the case of Auroraboot, make sure that the cloud config that you are mounting in the container (`-v $PWD/cloud_init.yaml:/cloud_init.yaml`) exists. Otherwise docker will create an empty directory to mount it on the container without any warnings and you will end up with an empty cloud config.
+In the case of Auroraboot, make sure that the cloud config that you are mounting in the container (`-v $PWD/cloud-config.yaml:/cloud-config.yaml`) exists. Otherwise docker will create an empty directory to mount it on the container without any warnings and you will end up with an empty cloud config.
 :::
 This will create a new ISO with your specified cloud configuration embedded in it. You can then use this ISO to boot your machine and automatically install Kairos with your desired settings.
 

--- a/docs/installation/edge-devices/nvidia_agx_orin.md
+++ b/docs/installation/edge-devices/nvidia_agx_orin.md
@@ -206,10 +206,10 @@ To customize the default cloud config of the board, generate the images mounting
 
 ```bash
 IMAGE=quay.io/kairos/ubuntu:22.04-core-arm64-nvidia-jetson-agx-orin-{{< KairosVersion  >}}
-CLOUD_CONFIG=/cloud/config.yaml
+CLOUD_CONFIG=/cloud/cloud-config.yaml
 docker run --rm --privileged --platform=linux/arm64 \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v "$CLOUD_CONFIG:/config.yaml:ro" \
+  -v "$CLOUD_CONFIG:/cloud-config.yaml:ro" \
   -v "$PWD/bootloader:/output" \
   quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
   --set "arch=arm64" \
@@ -218,7 +218,7 @@ docker run --rm --privileged --platform=linux/arm64 \
   --set "disable_http_server=true" \
   --set "disable_netboot=true" \
   --set "disk.partitions=true" \
-  --cloud-config /config.yaml
+  --cloud-config /cloud-config.yaml
 ```
 
 ### Debugging

--- a/docs/installation/edge-devices/nvidia_orin_nx.md
+++ b/docs/installation/edge-devices/nvidia_orin_nx.md
@@ -271,7 +271,7 @@ To customize the default cloud config of the board, generate the images mounting
 
 ```bash
 IMAGE=quay.io/kairos/ubuntu:22.04-core-arm64-nvidia-jetson-orin-nx-{{< KairosVersion  >}}
-CLOUD_CONFIG=/cloud/config.yaml
+CLOUD_CONFIG=/cloud/cloud-config.yaml
 docker run -v $CLOUD_CONFIG:/defaults.yaml --privileged \
         -e container_image=$IMAGE \
         -e STATE_SIZE="25500" \

--- a/docs/installation/manual.md
+++ b/docs/installation/manual.md
@@ -43,7 +43,7 @@ What do these settings do?
 
 [Check out the full configuration reference](/docs/reference/configuration).
 
-Save this file as config.yaml and pass it to the kairos agent during the installation process.
+Save this file as cloud-config.yaml and pass it to the kairos agent during the installation process.
 
 
 :::warning Warning
@@ -54,7 +54,7 @@ The command is disruptive and will erase any content on the drive.
 
 
 ```bash
-sudo kairos-agent manual-install --device "auto" config.yaml
+sudo kairos-agent manual-install --device "auto" cloud-config.yaml
 ```
 
 This will configure the node as a single-node Kubernetes cluster and set the default password and SSH keys as specified in the configuration file.

--- a/docs/installation/qrcode.md
+++ b/docs/installation/qrcode.md
@@ -60,7 +60,7 @@ The CLI allows to register a node with a screenshot, an image, or a token. Durin
 In a terminal window from your desktop/workstation, run:
 
 ```
-kairosctl register --reboot --device /dev/sda --config config.yaml
+kairosctl register --reboot --device /dev/sda --config cloud-config.yaml
 ```
 
 - The `--reboot` flag will make the node reboot automatically after the installation is completed.

--- a/docs/installation/takeover.md
+++ b/docs/installation/takeover.md
@@ -14,7 +14,7 @@ Kairos supports takeover installations. Here are a few summarized steps:
 ```bash
 export DEVICE=/dev/sda
 export IMAGE={{< OCI variant="core" >}}
-cat <<'EOF' > config.yaml
+cat <<'EOF' > cloud-config.yaml
 #cloud-config
 users:
 - name: "kairos"
@@ -24,7 +24,7 @@ users:
   ssh_authorized_keys:
   - github:mudler
 EOF
-export CONFIG_FILE=config.yaml
+export CONFIG_FILE=cloud-config.yaml
 docker run --privileged -v $PWD:/data -v /dev:/dev -ti $IMAGE kairos-agent manual-install --device $DEVICE --source dir:/ /data/$CONFIG_FILE
 ```
 

--- a/docs/reference/auroraboot.md
+++ b/docs/reference/auroraboot.md
@@ -51,7 +51,7 @@ Unfortunately for macOS systems we cannot run the netboot through docker as it's
 Building ISOs still works as long as you mount the container `/tmp` disk to a local dir so its exported there like so:
 
 ```bash
-docker run --rm -ti -v "$PWD"/config.yaml:/config.yaml -v ${PWD}:/tmp quay.io/kairos/auroraboot \
+docker run --rm -ti -v "$PWD"/cloud-config.yaml:/cloud-config.yaml -v ${PWD}:/tmp quay.io/kairos/auroraboot \
                     --set "artifact_version={{< KairosVersion  >}}" \
                     --set "release_version={{< KairosVersion  >}}" \
                     --set "flavor={{< FlavorCode  >}}" \
@@ -59,7 +59,7 @@ docker run --rm -ti -v "$PWD"/config.yaml:/config.yaml -v ${PWD}:/tmp quay.io/ka
                     --set "repository=kairos-io/kairos" \
                     --set "disable_http_server=true" \
                     --set "disable_netboot=true" \
-                    --cloud-config /config.yaml
+                    --cloud-config /cloud-config.yaml
 ```
 
 This will build the ISO and put the generated artifacts in the current dir under the `${PWD}/iso` dir.
@@ -203,18 +203,18 @@ Run AuroraBoot with a cloud-config to create an ISO with the embedded configurat
 Check we have the cloud config file:
 ```bash
 ls
-# config.yaml
+# cloud-config.yaml
 ```
 
 Build the ISO:
 ```bash
-docker run -v "$PWD"/config.yaml:/config.yaml \
+docker run -v "$PWD"/cloud-config.yaml:/cloud-config.yaml \
                     -v "$PWD"/build:/tmp/auroraboot \
                     --rm -ti quay.io/kairos/auroraboot \
                     --set container_image={{< OCI variant="core" >}} \
                     --set "disable_http_server=true" \
                     --set "disable_netboot=true" \
-                    --cloud-config /config.yaml \
+                    --cloud-config /cloud-config.yaml \
                     --set "state_dir=/tmp/auroraboot"
 ```
 
@@ -236,7 +236,7 @@ sudo ls -liah build/iso
 Check we have the cloud config file:
 ```bash
 ls
-# config.yaml
+# cloud-config.yaml
 ```
 
 Build the ISO:
@@ -249,7 +249,7 @@ docker run -v "$PWD"/build:/tmp/auroraboot -v /var/run/docker.sock:/var/run/dock
                     --set "repository=kairos-io/provider-kairos" \
                     --set "disable_http_server=true" \
                     --set "disable_netboot=true" \
-                    --cloud-config /config.yaml \
+                    --cloud-config /cloud-config.yaml \
                     --set "state_dir=/tmp/auroraboot"
 ```
 
@@ -375,7 +375,7 @@ cloud_config: |
 To use the configuration file with AuroraBoot, run AuroraBoot specifying the file or URL of the config as first argument:
 
 ```bash
-docker run --rm -ti -v "$PWD"/config.yaml:/config.yaml --net host quay.io/kairos/auroraboot /config.yaml
+docker run --rm -ti -v "$PWD"/cloud-config.yaml:/cloud-config.yaml --net host quay.io/kairos/auroraboot /cloud-config.yaml
 ```
 
 The CLI options can be used in place of specifying a file, and to set fields of it. Any field of the YAML file, excluding `cloud_config` can be configured with the `--set` for instance, to disable netboot we can run AuroraBoot with:
@@ -387,7 +387,7 @@ docker run --rm -ti --net host quay.io/kairos/auroraboot ....  --set "disable_ne
 To specify a cloud config file instead, use `--cloud-config` (can be also url):
 
 ```bash
-docker run --rm -ti -v "$PWD"/config.yaml:/config.yaml --net host quay.io/kairos/auroraboot .... --cloud-config /config.yaml
+docker run --rm -ti -v "$PWD"/cloud-config.yaml:/cloud-config.yaml --net host quay.io/kairos/auroraboot .... --cloud-config /cloud-config.yaml
 ```
 
 Both the config file and the cloud-config file can be a URL.
@@ -514,9 +514,9 @@ users:
 We would then set the user to `mudler` and the password to `foobar` when running AuroraBoot like the following:
 
 ```bash
-docker run --rm -ti -v "$PWD"/config.yaml:/config.yaml --net host \
+docker run --rm -ti -v "$PWD"/cloud-config.yaml:/cloud-config.yaml --net host \
                                 quay.io/kairos/auroraboot \
-                                --cloud-config /config.yaml \
+                                --cloud-config /cloud-config.yaml \
                                 --set "github.user=mudler" \
                                 --set "kairos.password=foobar"
 ```
@@ -604,7 +604,7 @@ Disabling TLS verification removes protection against man-in-the-middle attacks.
 ## Examples
 
 :::tip Note
-The example below are implying a `config.yaml` cloud config file to be present in the current directory.
+The example below are implying a `cloud-config.yaml` cloud config file to be present in the current directory.
 :::
 ### Offline ISO build from local container image
 
@@ -617,14 +617,14 @@ docker pull <IMAGE>
 Build the custom ISO with the cloud config:
 
 ```bash
-docker run -v "$PWD"/config.yaml:/config.yaml \
+docker run -v "$PWD"/cloud-config.yaml:/cloud-config.yaml \
              -v "$PWD"/build:/tmp/auroraboot \
              -v /var/run/docker.sock:/var/run/docker.sock \
              --rm -ti quay.io/kairos/auroraboot \
              --set container_image=oci:<IMAGE> \
              --set "disable_http_server=true" \
              --set "disable_netboot=true" \
-             --cloud-config /config.yaml \
+             --cloud-config /cloud-config.yaml \
              --set "state_dir=/tmp/auroraboot"
 ```
 
@@ -633,13 +633,13 @@ docker run -v "$PWD"/config.yaml:/config.yaml \
 Build the custom ISO with the cloud config:
 
 ```bash
-docker run -v "$PWD"/config.yaml:/config.yaml \
+docker run -v "$PWD"/cloud-config.yaml:/cloud-config.yaml \
              -v "$PWD"/build:/tmp/auroraboot \
              --rm -ti quay.io/kairos/auroraboot \
              --set container_image=oci:{{< OCI variant="core" >}} \
              --set "disable_http_server=true" \
              --set "disable_netboot=true" \
-             --cloud-config /config.yaml \
+             --cloud-config /cloud-config.yaml \
              --set "state_dir=/tmp/auroraboot"
 ```
 
@@ -655,14 +655,14 @@ mkdir -p data/boot/grub2
 # You can replace this step with your own grub config. This GRUB configuration is the boot menu of the ISO
 wget https://raw.githubusercontent.com/kairos-io/packages/main/packages/livecd/grub2/config/grub_live_bios.cfg -O data/boot/grub2/grub.cfg
 
-docker run -v "$PWD"/config.yaml:/config.yaml \
+docker run -v "$PWD"/cloud-config.yaml:/cloud-config.yaml \
              -v "$PWD"/data:/tmp/data \
              -v "$PWD"/build:/tmp/auroraboot \
              --rm -ti quay.io/kairos/auroraboot \
              --set container_image={{< OCI variant="core" >}} \
              --set "disable_http_server=true" \
              --set "disable_netboot=true" \
-             --cloud-config /config.yaml \
+             --cloud-config /cloud-config.yaml \
              --set "state_dir=/tmp/auroraboot" \
              --set "iso.overlay_iso=/tmp/data"
 ```
@@ -674,9 +674,9 @@ See the [Airgap example](/docs/examples/airgap) in the [examples section](/docs/
 ### Netboot from container images
 
 ```bash
-docker run -v "$PWD"/config.yaml:/config.yaml --rm -ti --net host quay.io/kairos/auroraboot \
+docker run -v "$PWD"/cloud-config.yaml:/cloud-config.yaml --rm -ti --net host quay.io/kairos/auroraboot \
         --set container_image={{< OCI variant="core" >}} \
-        --cloud-config /config.yaml
+        --cloud-config /cloud-config.yaml
 ```
 
 ### Extract netboot artifacts from an ISO
@@ -759,7 +759,7 @@ docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock \
   --set "disable_http_server=true" \
   --set "container_image={{< OCI variant="standard" >}}" \
   --set "disable_netboot=true" \
-  --cloud-config /aurora/config.yaml \
+  --cloud-config /aurora/cloud-config.yaml \
   --set "disk.gce=true" \
   --set "state_dir=/aurora"
 ```
@@ -774,7 +774,7 @@ docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock \
   --set "disable_http_server=true" \
   --set "container_image={{< OCI variant="standard" >}}" \
   --set "disable_netboot=true" \
-  --cloud-config /aurora/config.yaml \
+  --cloud-config /aurora/cloud-config.yaml \
   --set "disk.vhd=true" \
   --set "state_dir=/aurora"
 ```

--- a/docs/reference/build_raw_images_with_qemu.md
+++ b/docs/reference/build_raw_images_with_qemu.md
@@ -83,7 +83,7 @@ Use the following Bash script to generate raw bootable images using QEMU. This s
 #!/bin/bash
 # Generates raw bootable images with qemu
 set -ex
-CLOUD_INIT=${1:-cloud_init.yaml}
+CLOUD_INIT=${1:-cloud-config.yaml}
 QEMU=${QEMU:-qemu-system-x86_64}
 ISO=${2:-iso.iso}
 
@@ -127,7 +127,7 @@ To customize your installation:
 2. Pass the modified configuration as an argument to the script (optionally, pass the Kairos ISO as the second argument):
 
 ```bash
-./build_image.sh my_custom_cloud_config.yaml
+./build_image.sh my-custom-cloud-config.yaml
 ```
 
 This script will generate a raw disk image with the specified cloud configuration.

--- a/docs/reference/reset.md
+++ b/docs/reference/reset.md
@@ -142,7 +142,7 @@ metadata:
   namespace: system-upgrade
 type: Opaque
 stringData:
-  config.yaml: |
+  cloud-config.yaml: |
     #cloud-config
     hostname: testcluster-{{ trunc 4 .MachineID }}
     k3s:
@@ -157,12 +157,12 @@ stringData:
   add-config-file.sh: |
     #!/bin/sh
     set -e
-    if diff /host/run/system-upgrade/secrets/custom-script/config.yaml /host/oem/90_custom.yaml >/dev/null; then
+    if diff /host/run/system-upgrade/secrets/custom-script/cloud-config.yaml /host/oem/90_custom.yaml >/dev/null; then
         echo config present
         exit 0
     fi
     # we can't cp, that's a symlink!
-    cat /host/run/system-upgrade/secrets/custom-script/config.yaml > /host/oem/90_custom.yaml
+    cat /host/run/system-upgrade/secrets/custom-script/cloud-config.yaml > /host/oem/90_custom.yaml
     kairos-agent bootentry --select statereset
     sync
 


### PR DESCRIPTION
Closes kairos-io/kairos#2210.

The file users write and hand to Kairos was called four different things across the docs, so it wasn't always obvious they referred to the same file:

| Name | Files |
|---|---|
| `config.yaml` | 18 |
| `cloud-config.yaml` | 6 |
| `cloud_init.yaml` | 2 |
| `cloud_config.yaml` / `my_custom_cloud_config.yaml` | 2 |

This standardises on **`cloud-config.yaml`**, which matches the `--cloud-config` flag it's passed to and the `#cloud-config` line the file has to start with.

## What was deliberately left alone

Not every `config.yaml` in the docs is the user's file, and renaming those would have broken things:

- **`config.yaml` in AuroraBoot's output listings** (`ls -liah build/iso`) — AuroraBoot hardcodes that filename when it writes into its destination directory, so the listings show what really appears on disk.
- **`/etc/kairos/config.yaml`** and `/etc/elemental/config.yaml` — the installed system config paths.
- **`/etc/rancher/k3s/config.yaml`** — k3s's own config, unrelated.
- **`kind-config.yaml`, `fleet-config.yaml`** — different files entirely.
- **`/oem/90_custom.yaml`** — the installed config on the node, not the file the user authors.
- **`versioned_docs/`** — frozen snapshots describing released versions; renaming there would misdescribe what those releases shipped.

## Two judgement calls worth a look

- **`docs/reference/reset.md`** — the cloud config is delivered as a Kubernetes Secret whose key was `config.yaml`. I renamed the key and both script paths that read it together, so the manifest stays self-consistent. This also lines it up with `operator-docs/osartifact.md`, which already uses `cloud-config.yaml` as its key.
- **`docs/reference/build_raw_images_with_qemu.md`** — the "Customizing" example passes a deliberately *different* file from the script's default, so it stays distinct: `my_custom_cloud_config.yaml` → `my-custom-cloud-config.yaml`, fixing only the underscore style.

One incidental improvement: in the GCE/VHD examples the user's file and AuroraBoot's `state_dir` were both `$PWD`, so AuroraBoot's generated `config.yaml` landed on top of the user's. Renaming the source removes that collision.

## Testing

Text-only, all inside code fences and prose — no links, anchors or file paths that the site resolves. Verified after the change that no `cloud-cloud-config.yaml`-style double prefixes were introduced, that no snake_case variants survive, and that every remaining bare `config.yaml` in the current docs is one of the load-bearing cases listed above.

I haven't run the Docusaurus build locally.
