### PR TITLE
docs: standardize on docusaurus aurora boot format

### DIFF
--- a/docs/advanced/creating_custom_cloud_images.md
+++ b/docs/advanced/creating_custom_cloud_images.md
@@ -90,7 +90,7 @@ By default, AuroraBoot sets the state partition size to 3 times the size of the 
 ```bash
 docker run -v "$PWD"/build:/tmp/auroraboot \
              -v /var/run/docker.sock:/var/run/docker.sock \
-             --rm -ti quay.io/kairos/auroraboot \
+             --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
              --set container_image=my-custom-image \
              --set "disable_http_server=true" \
              --set "disable_netboot=true" \

--- a/docs/advanced/multi-disk-dynamic-partitioning.md
+++ b/docs/advanced/multi-disk-dynamic-partitioning.md
@@ -121,7 +121,7 @@ docker build -t my-kairos-multidisk .
 docker run --rm \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v "$PWD/output:/output" \
-  quay.io/kairos/auroraboot:v0.19.4 --debug \
+  quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} --debug \
   build-iso --output /output/ \
   docker:my-kairos-multidisk
 ```

--- a/docs/development/debugging-station.md
+++ b/docs/development/debugging-station.md
@@ -160,7 +160,7 @@ In this file, you can specify various settings for your debugging station. For e
 To automatically boot and install the debugging station, we can use [Auroraboot](/docs/reference/auroraboot). The following example shows how to use the cloud config above with it:
 
 ```bash
-cat <<EOF | docker run --rm -i --net host quay.io/kairos/auroraboot \
+cat <<EOF | docker run --rm -i --net host quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
                     --cloud-config - \
                     --set "container_image={{< OCI variant="standard" >}}"
 #cloud-config

--- a/docs/development/development.md
+++ b/docs/development/development.md
@@ -35,7 +35,7 @@ To build a Kairos ISO, you just call AuroraBoot with the generated OCI artifact:
 
 ```bash
 docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $PWD/build/:/output \
-  quay.io/kairos/auroraboot:v0.5.0 build-iso --output /output/ oci:myBaseKairos:v1.0.0 
+  quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} build-iso --output /output/ oci:myBaseKairos:v1.0.0
 ```
 
 You can see some example of builds in either the [kairos-init repo](https://github.com/kairos-io/kairos-init/blob/main/.github/workflows/test.yml), which builds a series of OCI containers of different base images, variants and platforms or on the [Kairos repo](https://github.com/kairos-io/kairos/tree/master/.github/workflows) itself which generates not only different types of platforms and variants and base images but also generates different types of artifacts, like ISOs, Trusted Boot ISOs, Trusted Boot upgrade artifacts, raw disk images and so on.

--- a/docs/examples/cluster-setup/p2p_e2e.md
+++ b/docs/examples/cluster-setup/p2p_e2e.md
@@ -99,7 +99,7 @@ We now can run [AuroraBoot](/docs/reference/auroraboot) with <OCICode variant="s
 AuroraBoot takes `cloud-config` files also from _STDIN_, so we will pipe the configuration file to it, and specify the container image that we want to use for our nodes:
 
 ``` bash
-cat <<EOF | docker run --rm -i --net host quay.io/kairos/auroraboot \
+cat <<EOF | docker run --rm -i --net host quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
                     --cloud-config - \
                     --set "container_image={{< OCI variant="standard" >}}"
 #cloud-config

--- a/docs/examples/k3s-stages.md
+++ b/docs/examples/k3s-stages.md
@@ -81,7 +81,7 @@ $ docker build -t k3s-stage-kairos .
 Again, this tutorial does not cover this part deeply as there already are docs that provide a deep insight into custom images such as the the [AuroraBoot page](/docs/reference/auroraboot/).
 
 ```bash
-$ docker run -v "$PWD"/build-iso:/tmp/auroraboot -v /var/run/docker.sock:/var/run/docker.sock --rm -ti quay.io/kairos/auroraboot --set container_image="oci:k3s-stage-kairos" --set "disable_http_server=true" --set "disable_netboot=true" --set "state_dir=/tmp/auroraboot"
+$ docker run -v "$PWD"/build-iso:/tmp/auroraboot -v /var/run/docker.sock:/var/run/docker.sock --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} --set container_image="oci:k3s-stage-kairos" --set "disable_http_server=true" --set "disable_netboot=true" --set "state_dir=/tmp/auroraboot"
 2:38PM INF Pulling container image 'k3s-stage-kairos' to '/tmp/auroraboot/temp-rootfs' (local: true)
 2:38PM INF Generating iso 'kairos' from '/tmp/auroraboot/temp-rootfs' to '/tmp/auroraboot/build'
 ```

--- a/docs/examples/kdump.md
+++ b/docs/examples/kdump.md
@@ -86,7 +86,7 @@ $ docker build -t kdump-kairos .
 Again, this tutorial does not cover this part deeply as there are docs providing a deep insight onto this like the [AuroraBoot page](/docs/reference/auroraboot/)
 
 ```bash
-$ docker run -v "$PWD"/build-iso:/tmp/auroraboot -v /var/run/docker.sock:/var/run/docker.sock --rm -ti quay.io/kairos/auroraboot --set container_image="oci:kdump-kairos" --set "disable_http_server=true" --set "disable_netboot=true" --set "state_dir=/tmp/auroraboot"
+$ docker run -v "$PWD"/build-iso:/tmp/auroraboot -v /var/run/docker.sock:/var/run/docker.sock --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} --set container_image="oci:kdump-kairos" --set "disable_http_server=true" --set "disable_netboot=true" --set "state_dir=/tmp/auroraboot"
 2:38PM INF Pulling container image 'kdump-kairos' to '/tmp/auroraboot/temp-rootfs' (local: true)
 2:38PM INF Generating iso 'kairos' from '/tmp/auroraboot/temp-rootfs' to '/tmp/auroraboot/build'
 ```

--- a/docs/examples/trusted-boot-firmware-sysext.md
+++ b/docs/examples/trusted-boot-firmware-sysext.md
@@ -96,7 +96,7 @@ docker run --rm -ti \
   -v "$PWD":/build \
   -v "$PWD/keys":/keys \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  quay.io/kairos/auroraboot \
+  quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
   sysext \
   --private-key=/keys/db.key \
   --certificate=/keys/db.pem \

--- a/docs/examples/virtual-box.md
+++ b/docs/examples/virtual-box.md
@@ -25,7 +25,7 @@ If you don't already have an ISO to boot, you can create one using the following
 set -e
 
 IMAGE="${IMAGE:-{{< RegistryURL  >}}/ubuntu:24.04-core-amd64-generic-{{< KairosVersion  >}}-uki}"
-AURORABOOT_IMAGE="{{< RegistryURL  >}}/auroraboot:latest"
+AURORABOOT_IMAGE="{{< RegistryURL  >}}/auroraboot:{{< AuroraBootVersion >}}"
 OUTDIR=$PWD/build
 
 cleanup() {

--- a/docs/installation/automated.md
+++ b/docs/installation/automated.md
@@ -152,7 +152,7 @@ $ docker pull $IMAGE
 $ docker run -v $PWD/cloud-config.yaml:/cloud-config.yaml \
                     -v $PWD/build:/tmp/auroraboot \
                     -v /var/run/docker.sock:/var/run/docker.sock \
-                    --rm -ti quay.io/kairos/auroraboot \
+                    --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
                     --set container_image=oci:$IMAGE \
                     --set "disable_http_server=true" \
                     --set "disable_netboot=true" \

--- a/docs/installation/edge-devices/raspberry.md
+++ b/docs/installation/edge-devices/raspberry.md
@@ -31,7 +31,7 @@ Create `build` directory and add `cloud-config.yaml`, then run:
 ```bash
 docker run --rm --privileged -v /var/run/docker.sock:/var/run/docker.sock \
                 -v $PWD/build/:/output \
-                quay.io/kairos/auroraboot:latest \
+                quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
                 --debug --set "disable_http_server=true" --set "disable_netboot=true" \
                 --set "state_dir=/output" --set "disk.raw=true" --set "arch=arm64" \
                 --cloud-config /output/cloud-config.yaml \

--- a/docs/installation/maas.md
+++ b/docs/installation/maas.md
@@ -29,7 +29,7 @@ Use AuroraBoot with `disk.maas=true`. AuroraBoot produces a raw disk image with 
 
 ```bash
 docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock \
-  -v $PWD:/aurora --rm -ti quay.io/kairos/auroraboot \
+  -v $PWD:/aurora --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
   --set "disable_http_server=true" \
   --set "disable_netboot=true" \
   --set "disk.maas=true" \

--- a/docs/installation/netboot.md
+++ b/docs/installation/netboot.md
@@ -140,7 +140,7 @@ later boots skip the pull.
 ## Use AuroraBoot
 
 ```bash
-docker run --rm -ti --net host quay.io/kairos/auroraboot \
+docker run --rm -ti --net host quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
                     --set "container_image={{< OCI variant="standard" >}}"
                     # Optionally:
                     # --cloud-config ....
@@ -157,7 +157,7 @@ If you'd rather plug Kairos into an existing netboot setup (pixiecore, dnsmasq, 
 First, extract the kernel, initrd and squashfs from a Kairos ISO:
 
 ```bash
-docker run --rm -v $PWD:/work quay.io/kairos/auroraboot \
+docker run --rm -v $PWD:/work quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
     netboot /work/kairos.iso /work/out kairos
 ```
 
@@ -166,7 +166,7 @@ This writes `kairos-kernel`, `kairos-initrd` and `kairos.squashfs` into `./out`.
 If you don't have a netboot server yet, AuroraBoot can be one. The `start-pixie` subcommand runs Pixiecore directly against the artifacts above:
 
 ```bash
-docker run --rm --net host -v $PWD:/work quay.io/kairos/auroraboot \
+docker run --rm --net host -v $PWD:/work quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
     start-pixie /work/cloud-config.yaml /work/out/kairos.squashfs 0.0.0.0 8090 \
                 /work/out/kairos-initrd /work/out/kairos-kernel
 ```

--- a/docs/reference/auroraboot.md
+++ b/docs/reference/auroraboot.md
@@ -51,7 +51,7 @@ Unfortunately for macOS systems we cannot run the netboot through docker as it's
 Building ISOs still works as long as you mount the container `/tmp` disk to a local dir so its exported there like so:
 
 ```bash
-docker run --rm -ti -v "$PWD"/cloud-config.yaml:/cloud-config.yaml -v ${PWD}:/tmp quay.io/kairos/auroraboot \
+docker run --rm -ti -v "$PWD"/cloud-config.yaml:/cloud-config.yaml -v ${PWD}:/tmp quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
                     --set "artifact_version={{< KairosVersion  >}}" \
                     --set "release_version={{< KairosVersion  >}}" \
                     --set "flavor={{< FlavorCode  >}}" \
@@ -83,7 +83,7 @@ AuroraBoot will download the artifacts required for bootstrapping the nodes, and
 For example, to netboot a machine with the latest version of Kairos and <FlavorCode /> using a cloud config, you would run the following command:
 
 ```bash
-docker run --rm -ti --net host quay.io/kairos/auroraboot \
+docker run --rm -ti --net host quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
                     --set "container_image={{< OCI variant="standard" >}}" \
                     --cloud-config https://...
 ```
@@ -114,7 +114,7 @@ Now we can run AuroraBoot with the container image we selected:
 By indicating a `container_image`, AuroraBoot will pull the image locally and start to serve it for network booting.
 
 ```bash
-docker run --rm -ti --net host quay.io/kairos/auroraboot \
+docker run --rm -ti --net host quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
                     --set "container_image={{< OCI variant="standard" >}}"
 ```
 
@@ -128,7 +128,7 @@ This implies that the host has a docker daemon, and we have to give access to it
 ```bash
 docker pull {{< OCI variant="standard" >}}
 # This will use the container image from the host's docker daemon
-docker run --rm -ti -v /var/run/docker.sock:/var/run/docker.sock --net host quay.io/kairos/auroraboot \
+docker run --rm -ti -v /var/run/docker.sock:/var/run/docker.sock --net host quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
                     --set "container_image=oci:{{< OCI variant="standard" >}}"
 ```
 </TabItem>
@@ -210,7 +210,7 @@ Build the ISO:
 ```bash
 docker run -v "$PWD"/cloud-config.yaml:/cloud-config.yaml \
                     -v "$PWD"/build:/tmp/auroraboot \
-                    --rm -ti quay.io/kairos/auroraboot \
+                    --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
                     --set container_image={{< OCI variant="core" >}} \
                     --set "disable_http_server=true" \
                     --set "disable_netboot=true" \
@@ -241,7 +241,7 @@ ls
 
 Build the ISO:
 ```bash
-docker run -v "$PWD"/build:/tmp/auroraboot -v /var/run/docker.sock:/var/run/docker.sock --rm -ti quay.io/kairos/auroraboot \
+docker run -v "$PWD"/build:/tmp/auroraboot -v /var/run/docker.sock:/var/run/docker.sock --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
                     --set "artifact_version={{< KairosVersion  >}}-{{< K3sVersionOCI  >}}" \
                     --set "release_version={{< KairosVersion  >}}" \
                     --set "flavor={{< FlavorCode  >}}" \
@@ -376,19 +376,19 @@ cloud_config: |
 To use the configuration file with AuroraBoot, run AuroraBoot specifying the file or URL of the config as first argument:
 
 ```bash
-docker run --rm -ti -v "$PWD"/cloud-config.yaml:/cloud-config.yaml --net host quay.io/kairos/auroraboot /cloud-config.yaml
+docker run --rm -ti -v "$PWD"/cloud-config.yaml:/cloud-config.yaml --net host quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} /cloud-config.yaml
 ```
 
 The CLI options can be used in place of specifying a file, and to set fields of it. Any field of the YAML file, excluding `cloud_config` can be configured with the `--set` for instance, to disable netboot we can run AuroraBoot with:
 
 ```bash
-docker run --rm -ti --net host quay.io/kairos/auroraboot ....  --set "disable_netboot=true"
+docker run --rm -ti --net host quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} ....  --set "disable_netboot=true"
 ```
 
 To specify a cloud config file instead, use `--cloud-config` (can be also url):
 
 ```bash
-docker run --rm -ti -v "$PWD"/cloud-config.yaml:/cloud-config.yaml --net host quay.io/kairos/auroraboot .... --cloud-config /cloud-config.yaml
+docker run --rm -ti -v "$PWD"/cloud-config.yaml:/cloud-config.yaml --net host quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} .... --cloud-config /cloud-config.yaml
 ```
 
 Both the config file and the cloud-config file can be a URL.
@@ -421,7 +421,7 @@ cp my-installer-script.sh files-iso/extra/
 
 docker run -v "$PWD"/files-iso:/files-iso \
              -v "$PWD"/build:/tmp/auroraboot \
-             --rm -ti quay.io/kairos/auroraboot \
+             --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
              build-iso --overlay-iso /files-iso \
              --output /tmp/auroraboot $IMAGE
 ```
@@ -432,7 +432,7 @@ docker run -ti --rm \
              -v $PWD/system-extensions:/system-extensions \
              -v $PWD/build:/result \
              -v $PWD/keys/:/keys \
-             quay.io/kairos/auroraboot \
+             quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
              build-uki -t iso -d /result/ \
              --overlay-iso /system-extensions \
              $CONTAINER_IMAGE
@@ -464,7 +464,7 @@ cp my-custom-tool rootfs-overlay/usr/local/bin/
 
 docker run -v "$PWD"/rootfs-overlay:/rootfs-overlay \
              -v "$PWD"/build:/tmp/auroraboot \
-             --rm -ti quay.io/kairos/auroraboot \
+             --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
              build-iso --overlay-rootfs /rootfs-overlay \
              --output /tmp/auroraboot $IMAGE
 ```
@@ -475,7 +475,7 @@ docker run -ti --rm \
              -v $PWD/rootfs-overlay:/rootfs-overlay \
              -v $PWD/build:/result \
              -v $PWD/keys/:/keys \
-             quay.io/kairos/auroraboot \
+             quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
              build-uki -t iso -d /result/ \
              --overlay-rootfs /rootfs-overlay \
              $CONTAINER_IMAGE
@@ -516,7 +516,7 @@ We would then set the user to `mudler` and the password to `foobar` when running
 
 ```bash
 docker run --rm -ti -v "$PWD"/cloud-config.yaml:/cloud-config.yaml --net host \
-                                quay.io/kairos/auroraboot \
+                                quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
                                 --cloud-config /cloud-config.yaml \
                                 --set "github.user=mudler" \
                                 --set "kairos.password=foobar"
@@ -528,7 +528,7 @@ We can indeed use the template in the example folder with the command above:
 
 ```bash
 docker run --rm -ti --net host \
-                        quay.io/kairos/auroraboot \
+                        quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
                         --cloud-config https://raw.githubusercontent.com/kairos-io/kairos/master/examples/auroraboot/master-template.yaml \
                         --set "github.user=mudler" \
                         --set "kairos.password=foobar"
@@ -537,7 +537,7 @@ docker run --rm -ti --net host \
 To pass-by a cloud-config via pipes, set `--cloud-config -`, for example:
 
 ```yaml
-cat <<EOF | docker run --rm -i --net host quay.io/kairos/auroraboot \
+cat <<EOF | docker run --rm -i --net host quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
                     --cloud-config - \
                     --set "container_image={{< OCI variant="standard" >}}"
 #cloud-config
@@ -621,7 +621,7 @@ Build the custom ISO with the cloud config:
 docker run -v "$PWD"/cloud-config.yaml:/cloud-config.yaml \
              -v "$PWD"/build:/tmp/auroraboot \
              -v /var/run/docker.sock:/var/run/docker.sock \
-             --rm -ti quay.io/kairos/auroraboot \
+             --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
              --set container_image=oci:<IMAGE> \
              --set "disable_http_server=true" \
              --set "disable_netboot=true" \
@@ -636,7 +636,7 @@ Build the custom ISO with the cloud config:
 ```bash
 docker run -v "$PWD"/cloud-config.yaml:/cloud-config.yaml \
              -v "$PWD"/build:/tmp/auroraboot \
-             --rm -ti quay.io/kairos/auroraboot \
+             --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
              --set container_image=oci:{{< OCI variant="core" >}} \
              --set "disable_http_server=true" \
              --set "disable_netboot=true" \
@@ -659,7 +659,7 @@ wget https://raw.githubusercontent.com/kairos-io/packages/main/packages/livecd/g
 docker run -v "$PWD"/cloud-config.yaml:/cloud-config.yaml \
              -v "$PWD"/data:/tmp/data \
              -v "$PWD"/build:/tmp/auroraboot \
-             --rm -ti quay.io/kairos/auroraboot \
+             --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
              --set container_image={{< OCI variant="core" >}} \
              --set "disable_http_server=true" \
              --set "disable_netboot=true" \
@@ -675,7 +675,7 @@ See the [Airgap example](/docs/examples/airgap) in the [examples section](/docs/
 ### Netboot from container images
 
 ```bash
-docker run -v "$PWD"/cloud-config.yaml:/cloud-config.yaml --rm -ti --net host quay.io/kairos/auroraboot \
+docker run -v "$PWD"/cloud-config.yaml:/cloud-config.yaml --rm -ti --net host quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
         --set container_image={{< OCI variant="core" >}} \
         --cloud-config /cloud-config.yaml
 ```
@@ -685,7 +685,7 @@ docker run -v "$PWD"/cloud-config.yaml:/cloud-config.yaml --rm -ti --net host qu
 The `netboot` subcommand pulls the kernel, initrd and squashfs out of a Kairos ISO so they can be served by any netboot infrastructure (pixiecore, dnsmasq, an existing TFTP server, etc.).
 
 ```bash
-docker run --rm -v $PWD:/work quay.io/kairos/auroraboot \
+docker run --rm -v $PWD:/work quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
     netboot /work/kairos.iso /work/out kairos
 ```
 
@@ -699,7 +699,7 @@ Positional arguments:
 The `start-pixie` subcommand runs Pixiecore against a kernel, initrd and squashfs you already have — for example, the files produced by `netboot` above, or files built by your own pipeline.
 
 ```bash
-docker run --rm --net host -v $PWD:/work quay.io/kairos/auroraboot \
+docker run --rm --net host -v $PWD:/work quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
     start-pixie /work/cloud-config.yaml /work/out/kairos.squashfs 0.0.0.0 8090 \
                 /work/out/kairos-initrd /work/out/kairos-kernel
 ```
@@ -723,7 +723,7 @@ Consider the following example:
 
 ```bash
 docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock \
-  -v $PWD:/aurora --rm -ti quay.io/kairos/auroraboot \
+  -v $PWD:/aurora --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
   --debug \
   --set "disable_http_server=true" \
   --set "disable_netboot=true" \
@@ -738,7 +738,7 @@ If you need to ensure the state partition can accommodate larger future images, 
 
 ```bash
 docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock \
-  -v $PWD:/aurora --rm -ti quay.io/kairos/auroraboot \
+  -v $PWD:/aurora --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
   --debug \
   --set "disable_http_server=true" \
   --set "disable_netboot=true" \
@@ -755,7 +755,7 @@ To generate GCE and VHD images set `disk.gce=true` or `disk.vhd=true` respective
 ```bash
 # Build a GCE-compatible image
 docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock \
-  -v $PWD:/aurora --rm -ti quay.io/kairos/auroraboot \
+  -v $PWD:/aurora --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
   --debug \
   --set "disable_http_server=true" \
   --set "container_image={{< OCI variant="standard" >}}" \
@@ -770,7 +770,7 @@ or for VHD images:
 ```bash
 # Build a VHD image compatible with Azure
 docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock \
-  -v $PWD:/aurora --rm -ti quay.io/kairos/auroraboot \
+  -v $PWD:/aurora --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
   --debug \
   --set "disable_http_server=true" \
   --set "container_image={{< OCI variant="standard" >}}" \
@@ -789,7 +789,7 @@ for the end-to-end deployment guide.
 ```bash
 # Build a MaaS-ready image
 docker run --privileged -v /var/run/docker.sock:/var/run/docker.sock \
-  -v $PWD:/aurora --rm -ti quay.io/kairos/auroraboot \
+  -v $PWD:/aurora --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
   --debug \
   --set "disable_http_server=true" \
   --set 'container_image={{< OCI variant="standard" >}}' \
@@ -833,7 +833,7 @@ cloud_config: |
 And then run:
 
 ```bash
-docker run -v "$PWD"/aurora.yaml:/aurora.yaml --rm -ti --net host quay.io/kairos/auroraboot /aurora.yaml
+docker run -v "$PWD"/aurora.yaml:/aurora.yaml --rm -ti --net host quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} /aurora.yaml
 ```
 
 
@@ -868,7 +868,7 @@ You must provide:
 For example if your ISO is at `/opt/images/kairos-uki.iso`, start AuroraBoot with:
 
 ```bash
-docker run --privileged -v /opt/images/:/aurora --rm -ti quay.io/kairos/auroraboot uki-pxe /aurora/kairos-uki.iso
+docker run --privileged -v /opt/images/:/aurora --rm -ti quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} uki-pxe /aurora/kairos-uki.iso
 ```
 
 ---

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -110,7 +110,7 @@ const docsVersionCustomFields = {
     k0sVersion: 'v1.36.1+k0s.0',
     flavorOptions: hadronFlavorOptionsV412,
     providerVersion: 'v2.16.1',
-    auroraBootVersion: 'v0.24.0',
+    auroraBootVersion: 'v0.26.2',
     kairosInitVersion: 'v0.14.6',
   },
   'v4.0.3': {

--- a/operator-docs/osartifact.md
+++ b/operator-docs/osartifact.md
@@ -603,7 +603,7 @@ spec:
 
   importers:
     - name: generate-uki-keys
-      image: quay.io/kairos/auroraboot:latest
+      image: quay.io/kairos/auroraboot:{{< AuroraBootVersion >}}
       command: ["/bin/sh", "-c"]
       args:
         - auroraboot genkey my-uki -o /keys

--- a/quickstart/trusted-boot.md
+++ b/quickstart/trusted-boot.md
@@ -36,7 +36,7 @@ If you've got SELinux Enabled, you will get a "Permission denied" error. To avoi
 :::
 
 ```bash
-docker run -v $PWD/keys:/work/keys -ti --rm quay.io/kairos/auroraboot:v0.16.2 genkey --expiration-in-days 365 -o /work/keys "E-corp"
+docker run -v $PWD/keys:/work/keys -ti --rm quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} genkey --expiration-in-days 365 -o /work/keys "E-corp"
 ```
 
 If everything went correctly you should see similar output to this:
@@ -107,7 +107,7 @@ If you've got SELinux Enabled, you will get a "Permission denied" error. To avoi
 docker run -v /var/run/docker.sock:/var/run/docker.sock \
  -v ${PWD}/build/:/output \
  -v ${PWD}/keys:/keys \
- quay.io/kairos/auroraboot:v0.16.2 \
+ quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
  build-uki \
  --output-dir /output/ \
  --public-keys /keys \


### PR DESCRIPTION
Ensures that all references of auroraboot standardize on the same auroraboot version.

Based on https://github.com/kairos-io/kairos/issues/4294, I continued to review to ensure that AuroraBoot is referenced to latest across documentation.