### PR TITLE
docs(media): add CNCF Blog article

### DIFF
--- a/src/components/designs/content.ts
+++ b/src/components/designs/content.ts
@@ -77,6 +77,15 @@ export const alternativeTracks = [
 
 export const pressItems: PressItem[] = [
   {
+    dateISO: '2026-08-14',
+    dateLabel: 'Aug 14, 2026',
+    source: 'CNCF Blog',
+    text: 'Eleven minutes, zero humans: Building a self-healing Kubernetes upgrade pipeline on Kairos',
+    url: 'TODO',
+    logo: '/img/logo_cloudnative.png',
+    logoAlt: 'CNCF logo',
+  },
+  {
     dateISO: '2026-05-13',
     dateLabel: 'May 13, 2026',
     source: 'CNCF Blog',


### PR DESCRIPTION
## Summary

- Adds entry for _Eleven minutes, zero humans: Building a self-healing Kubernetes upgrade pipeline on Kairos_ on the CNCF Blog
- URL placeholder (`TODO`) — will be updated once article goes live before merge

## Before merging

- [ ] Replace `TODO` with live CNCF Blog URL

