### PR TITLE
docs(nvidia): add DGX Spark build guide

### DIFF
--- a/docs/installation/edge-devices/nvidia-jetson-images.md
+++ b/docs/installation/edge-devices/nvidia-jetson-images.md
@@ -30,6 +30,8 @@ replacement.
 
 For the full list of `--model` values (including `generic`, `rpi3`, `rpi4`) see
 [The Kairos Factory](/docs/reference/kairos-factory/#supported-device-targets).
+NVIDIA DGX Spark uses a separate UEFI/SBSA flow. See
+[NVIDIA DGX Spark](/docs/installation/nvidia_dgx_spark/).
 
 ## Prerequisites
 

--- a/docs/installation/edge-devices/nvidia_dgx_spark.md
+++ b/docs/installation/edge-devices/nvidia_dgx_spark.md
@@ -1,0 +1,64 @@
+---
+title: "NVIDIA DGX Spark"
+sidebar_label: "NVIDIA DGX Spark"
+description: Build and install Kairos on NVIDIA DGX Spark.
+slug: /installation/nvidia_dgx_spark
+---
+
+NVIDIA DGX Spark uses the GB10 Grace Blackwell platform. It is an ARM64 UEFI/SBSA
+system, not a Jetson/L4T device. Build its Kairos image with the
+`nvidia-dgx-spark` model.
+
+## Prerequisites
+
+- An NVIDIA DGX Spark.
+- Docker with `buildx`.
+- A `kairos-init` release that includes DGX Spark support.
+- An ARM64 build host or QEMU support for ARM64 cross-builds.
+
+## Build the image
+
+Create this `Dockerfile`:
+
+```Dockerfile
+FROM quay.io/kairos/kairos-init:{{< KairosInitVersion >}} AS kairos-init
+
+FROM ubuntu:24.04
+ARG VERSION=1.0.0
+RUN --mount=type=bind,from=kairos-init,src=/kairos-init,dst=/kairos-init \
+    /kairos-init --version "${VERSION}" --model nvidia-dgx-spark
+```
+
+Build and push the ARM64 image:
+
+```bash
+docker buildx build --platform linux/arm64 \
+  -t my-registry.example.com/kairos-dgx-spark:v1.0.0 \
+  --push .
+```
+
+On an ARM64 host, you can use `docker build` without the `--platform` option.
+
+## What the model configures
+
+The `nvidia-dgx-spark` model configures these platform components:
+
+- The NVIDIA HWE kernel for Ubuntu 24.04.
+- The open NVIDIA 580 kernel modules and headless driver.
+- NVIDIA DGX BaseOS and Spark package repositories.
+- NVIDIA and Mellanox firmware and platform tools.
+- The serial console and kernel arguments that DGX Spark requires.
+- `fwupd` for UEFI capsule updates through ESRT.
+
+The model does not add the CUDA repository. Add NVIDIA's ARM64 SBSA CUDA
+repository in a derived image if you need host CUDA packages.
+
+## Create installable artifacts
+
+Pass the pushed image to [AuroraBoot](/docs/reference/auroraboot/) to create an
+ISO or another Kairos artifact. DGX Spark uses the standard Kairos installation
+and upgrade flow because it boots with UEFI.
+
+You can use providers, Trusted Boot, and stage extensions with this model. See
+the [Kairos Factory reference](/docs/reference/kairos-factory/) for the available
+options.

--- a/docs/installation/edge-devices/nvidia_dgx_spark.md
+++ b/docs/installation/edge-devices/nvidia_dgx_spark.md
@@ -55,9 +55,27 @@ repository in a derived image if you need host CUDA packages.
 
 ## Create installable artifacts
 
-Pass the pushed image to [AuroraBoot](/docs/reference/auroraboot/) to create an
-ISO or another Kairos artifact. DGX Spark uses the standard Kairos installation
-and upgrade flow because it boots with UEFI.
+Create an output directory:
+
+```bash
+mkdir -p build
+```
+
+Run AuroraBoot with the image that you pushed:
+
+```bash
+docker run --rm -v "$PWD/build:/output" \
+  quay.io/kairos/auroraboot:{{< AuroraBootVersion >}} \
+  build-iso --output /output/ \
+  oci:my-registry.example.com/kairos-dgx-spark:v1.0.0
+```
+
+AuroraBoot writes the installable ISO and its checksum to the `build` directory.
+See the [AuroraBoot reference](/docs/reference/auroraboot/) for other artifact
+types and configuration options.
+
+DGX Spark uses the standard Kairos installation and upgrade flow because it
+boots with UEFI.
 
 You can use providers, Trusted Boot, and stage extensions with this model. See
 the [Kairos Factory reference](/docs/reference/kairos-factory/) for the available

--- a/docs/reference/kairos-factory.mdx
+++ b/docs/reference/kairos-factory.mdx
@@ -149,7 +149,7 @@ Here is a list of flags, explanation and what are the possible and default value
 | -v                         | Set version of the artifact that we are building                  | Any                        | None (REQUIRED) |
 | -l                         | Sets the log level                                                | info,warn,debug,trace      | info            |
 | -s                         | Sets the stage to run                                             | install, init, all         | all             |
-| -m                         | Sets the model — pulls in board-specific packages, kernels and cloud-configs. See [Supported device targets](#supported-device-targets). | generic, rpi3, rpi4, nvidia-jetson-agx-orin, nvidia-jetson-orin-nx, nvidia-jetson-thor | generic         |
+| -m                         | Sets the model — pulls in board-specific packages, kernels and cloud-configs. See [Supported device targets](#supported-device-targets). | generic, rpi3, rpi4, nvidia-jetson-agx-orin, nvidia-jetson-orin-nx, nvidia-jetson-thor, nvidia-dgx-spark | generic         |
 | -p / --provider            | Provider plugin name (repeatable for multiple providers)          | e.g. k3s, k0s              | None            |
 | --provider-&lt;NAME&gt;-version | Version for the given provider (e.g. `--provider-k3s-version`)     | Release tag from provider (e.g. k3s: [v1.35.1+k3s1](https://github.com/k3s-io/k3s/releases), k0s: [v1.35.1+k0s.1](https://github.com/k0sproject/k0s/releases)) | None            |
 | --provider-&lt;NAME&gt;-config  | Config file for the given provider (e.g. `--provider-k3s-config`)  | Path to config file        | None            |
@@ -186,12 +186,16 @@ on that hardware without extra work in your Dockerfile.
 | `nvidia-jetson-agx-orin`     | NVIDIA Jetson AGX Orin (L4T r36.x)                                 | [NVIDIA Jetson (build image)](/docs/installation/nvidia-jetson-images/) |
 | `nvidia-jetson-orin-nx`      | NVIDIA Jetson Orin NX (L4T r36.x)                                  | [NVIDIA Jetson (build image)](/docs/installation/nvidia-jetson-images/) |
 | `nvidia-jetson-thor`         | NVIDIA Jetson AGX Thor / T264 (L4T r38.x)                          | [NVIDIA Jetson (build image)](/docs/installation/nvidia-jetson-images/) |
+| `nvidia-dgx-spark`           | NVIDIA DGX Spark / GB10 (ARM64 UEFI/SBSA)                          | [NVIDIA DGX Spark](/docs/installation/nvidia_dgx_spark/) |
 
 The Jetson build guide covers all three NVIDIA models in one place; per-board flashing and
 install steps stay on the existing device pages
 ([AGX Orin](/docs/installation/nvidia_agx_orin/),
 [Orin NX](/docs/installation/nvidia_orin_nx/),
 [AGX Thor](/docs/installation/nvidia_agx_thor/)).
+
+DGX Spark is not a Jetson/L4T device. Use its
+[separate build guide](/docs/installation/nvidia_dgx_spark/).
 
 ## Phases
 


### PR DESCRIPTION
## Summary

- add a dedicated NVIDIA DGX Spark image build guide
- document the `nvidia-dgx-spark` factory model and platform behavior
- keep DGX Spark separate from the Jetson/L4T build flow

Follow-up to kairos-io/kairos-init#421.

## Verification

- `npm test` (11 tests passed)
- `git diff --check`

`npm ci` could not download all locked packages because this environment returned `403 egress denied by policy` for npm tarballs. The missing `tsc` and `docusaurus` binaries prevented local typecheck and site-build verification; CI remains the full build check.